### PR TITLE
chore(#2): Unify Makefile start target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,18 +24,10 @@ This will:
 
 ## Run dev server
 
-```bash
-make install
-```
-
-## Run in development mode
-
 > You will need a database instance accessible locally. For convenience a simple sqlite DB is provided as a default. This db was already initialized if you ran the `make install-dev` above. See below for more details about the DB.
 
-Run the API with hot-reload:
-
 ```bash
-make start-dev
+make dev
 ```
 
 Verify the API is running:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install-pg: install
 install-mariadb: install
 	pip install -r requirements.txt -r requirements-mariadb.txt
 
-start: migrate
+run: migrate
 	@bash -c '\
 	set -uo pipefail; \
 	PIDS=(); \
@@ -45,6 +45,9 @@ start: migrate
 	cleanup; \
 	exit $$STATUS'
 
+# Legacy "start" target, prefer run target instead
+start: run
+
 ping:
 	curl localhost:4207
 
@@ -61,7 +64,7 @@ install-dev:
 	poetry install --with dev --all-extras
 	$(MAKE) migrate
 
-start-dev: migrate
+dev: migrate
 	@bash -c '\
 	set -uo pipefail; \
 	PIDS=(); \
@@ -88,6 +91,9 @@ start-dev: migrate
 	set -e; \
 	cleanup; \
 	exit $$STATUS'
+
+# Legacy "start-dev" target, prefer dev target instead
+start-dev: dev
 
 test:
 	poetry run pytest

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,32 @@ install-mariadb: install
 	pip install -r requirements.txt -r requirements-mariadb.txt
 
 start: migrate
-	python -m uvicorn warden.api.main:app --host 0.0.0.0 --port 4207
-
-start-scheduler:
-	python  -m warden.scheduler
+	@bash -c '\
+	set -uo pipefail; \
+	PIDS=(); \
+	cleanup() { \
+		trap - SIGINT SIGTERM EXIT; \
+		if [ "$${#PIDS[@]}" -gt 0 ]; then \
+			kill -TERM "$${PIDS[@]}" 2>/dev/null || true; \
+			for pid in "$${PIDS[@]}"; do \
+				wait "$$pid" 2>/dev/null || true; \
+			done; \
+		fi; \
+	}; \
+	on_signal() { \
+		cleanup; \
+		exit 0; \
+	}; \
+	trap on_signal SIGINT SIGTERM; \
+	trap cleanup EXIT; \
+	${PYTHON} -m uvicorn warden.api.main:app --host 0.0.0.0 --port 4207 & PIDS+=($$!); \
+	${PYTHON} -m warden.scheduler & PIDS+=($$!); \
+	set +e; \
+	wait -n "$${PIDS[@]}"; \
+	STATUS=$$?; \
+	set -e; \
+	cleanup; \
+	exit $$STATUS'
 
 ping:
 	curl localhost:4207
@@ -40,7 +62,32 @@ install-dev:
 	$(MAKE) migrate
 
 start-dev: migrate
-	poetry run python -m debugpy --listen 0.0.0.0:8888 -m uvicorn warden.api.main:app --reload --host 0.0.0.0 --port 4207
+	@bash -c '\
+	set -uo pipefail; \
+	PIDS=(); \
+	cleanup() { \
+		trap - SIGINT SIGTERM EXIT; \
+		if [ "$${#PIDS[@]}" -gt 0 ]; then \
+			kill -TERM "$${PIDS[@]}" 2>/dev/null || true; \
+			for pid in "$${PIDS[@]}"; do \
+				wait "$$pid" 2>/dev/null || true; \
+			done; \
+		fi; \
+	}; \
+	on_signal() { \
+		cleanup; \
+		exit 0; \
+	}; \
+	trap on_signal SIGINT SIGTERM; \
+	trap cleanup EXIT; \
+	${PYTHON} -m debugpy --listen 0.0.0.0:8888 -m uvicorn warden.api.main:app --reload --host 0.0.0.0 --port 4207 & PIDS+=($$!); \
+	${PYTHON} -m debugpy --listen 0.0.0.0:8889 -m warden.scheduler & PIDS+=($$!); \
+	set +e; \
+	wait -n "$${PIDS[@]}"; \
+	STATUS=$$?; \
+	set -e; \
+	cleanup; \
+	exit $$STATUS'
 
 test:
 	poetry run pytest
@@ -63,4 +110,4 @@ run-db:
 
 # Usage: make alembic ARGS="upgrade head"
 alembic:
-	python -m alembic -c warden/api/alembic.ini $(ARGS)
+	${PYTHON} -m alembic -c warden/api/alembic.ini $(ARGS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ mariadb = ["asyncmy"]
 
 
 [tool.poetry.scripts]
-start = "uvicorn warden.main:app --reload --host 0.0.0.0 --port 8000"
-start-scheduler = "scheduler.main:main"
+start = "warden.api.main:app"
+start-scheduler = "warden.scheduler.main:main"
 
 [tool.poetry.group.dev.dependencies]
 debugpy = "^1.8.20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,6 @@ postgres = ["asyncpg", "psycopg"]
 mariadb = ["asyncmy"]
 
 
-[tool.poetry.scripts]
-start = "warden.api.main:app"
-start-scheduler = "warden.scheduler.main:main"
-
 [tool.poetry.group.dev.dependencies]
 debugpy = "^1.8.20"
 pytest = "^9.0.2"


### PR DESCRIPTION
Targets for `start` and `start-dev` now:
- start traps
- launch subprocesses tracking their PIDs
- If one or more process fails and/or if the parent process is interrupted, send a termination signal to all children processes, wait for them to end cleanly