### PR TITLE
test(ci): Test install in different envs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,11 +13,11 @@
 
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-	"service": "warden-rockylinux-9",
+	"service": "warden-rocky-9",
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/workspaces/warden"
+	"workspaceFolder": "/workspaces/warden",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -35,7 +35,15 @@
 	// "postCreateCommand": "cat /etc/os-release",
 
 	// Configure tool-specific properties.
-	// "customizations": {},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.debugpy"
+			]
+		}
+	}
 
 	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "devcontainer"

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,41 +1,42 @@
 version: '3.9'
 services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
-  warden-rhel-8-8:
-    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
-    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
-    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
-    # array). The sample below assumes your primary file is in the root of your project.
-    #
-    # build:
-    #   context: .
-    #   dockerfile: .devcontainer/Dockerfile
-    image: redhat/ubi8:8.8
-    volumes:
-      # Update this to wherever you want VS Code to mount the folder of your project
-      - ../:/workspaces/warden:cached
+  # warden-rhel-8-8:
+  #   # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
+  #   # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+  #   # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
+  #   # array). The sample below assumes your primary file is in the root of your project.
+  #   #
+  #   build:
+  #     context: ..
+  #     dockerfile: .devcontainer/rhel8.Dockerfile
+  #   volumes:
+  #     # Update this to wherever you want VS Code to mount the folder of your project
+  #     - ../:/workspaces/warden:cached
 
-    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
-    # cap_add:
-    #   - SYS_PTRACE
-    # security_opt:
-    #   - seccomp:unconfined
+  #   # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+  #   # cap_add:
+  #   #   - SYS_PTRACE
+  #   # security_opt:
+  #   #   - seccomp:unconfined
 
-    # Overrides default command so things don't shut down after the process ends.
-    command: sleep infinity
+  #   # Overrides default command so things don't shut down after the process ends.
+  #   command: sleep infinity
  
 
-  warden-rockylinux-8:
-    image: rockylinux:8
-    volumes:
-      - ../:/workspaces/warden:cached
-    command: sleep infinity
- 
-
-  warden-rockylinux-9:
+  warden-rocky-8:
     build:
-      context: .
-      dockerfile: rocky9.Dockerfile
+      context: ..
+      dockerfile: .devcontainer/rocky8.Dockerfile
+    volumes:
+      - ../:/workspaces/warden:cached
+    command: sleep infinity
+ 
+
+  warden-rocky-9:
+    build:
+      context: ..
+      dockerfile: .devcontainer/rocky9.Dockerfile
     volumes:
       - ../:/workspaces/warden:cached
     command: sleep infinity

--- a/.devcontainer/install.rocky8.sh
+++ b/.devcontainer/install.rocky8.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -ex
+
+dnf makecache
+dnf -y update
+dnf -y install dnf-plugins-core
+dnf config-manager --set-enabled powertools
+dnf -y install \
+  wget \
+  bzip2 \
+  perl \
+  gcc \
+  gcc-c++\
+  git \
+  gnupg \
+  make \
+  munge \
+  munge-devel \
+  python${PYTHON_VERSION}-devel \
+  python${PYTHON_VERSION}-pip \
+  python${PYTHON_VERSION} \
+  mariadb-server \
+  mariadb-devel \
+  psmisc \
+  bash-completion \
+  vim-enhanced \
+  http-parser-devel \
+  json-c-devel
+dnf clean all
+rm -rf /var/cache/dnf
+
+alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1

--- a/.devcontainer/install.rocky9.sh
+++ b/.devcontainer/install.rocky9.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -ex
+
+dnf makecache
+dnf -y update
+dnf -y install dnf-plugins-core
+dnf config-manager --set-enabled crb
+dnf -y install \
+  wget \
+  bzip2 \
+  perl \
+  gcc \
+  gcc-c++\
+  git \
+  gnupg \
+  make \
+  munge \
+  munge-devel \
+  python${PYTHON_VERSION}-devel \
+  python${PYTHON_VERSION}-pip \
+  python${PYTHON_VERSION} \
+  mariadb \
+  mariadb-server \
+  mariadb-devel \
+  postgresql \
+  psmisc \
+  bash-completion \
+  vim-enhanced \
+  http-parser-devel \
+  json-c-devel \
+  cmake \
+  clang-tools-extra \
+  procps \
+  iputils \
+  net-tools \
+  openblas-devel \
+  jq \
+  iputils \
+  net-tools \
+  libyaml-devel \
+  procps \
+  lua-devel
+dnf clean all
+rm -rf /var/cache/dnf
+
+alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1

--- a/.devcontainer/rocky8.Dockerfile
+++ b/.devcontainer/rocky8.Dockerfile
@@ -1,10 +1,10 @@
-FROM rockylinux:9
+FROM rockylinux:8
 
 ARG PYTHON_VERSION=3.11
 ENV PYTHON_VERSION=${PYTHON_VERSION}
 
-COPY .devcontainer/install.rocky9.sh /tmp/install.rocky9.sh
-RUN sh /tmp/install.rocky9.sh
+COPY .devcontainer/install.rocky8.sh /tmp/install.rocky8.sh
+RUN sh /tmp/install.rocky8.sh
 
 RUN groupadd --gid 1000 devuser && \
   useradd --uid 1000 --gid 1000 -m -s /bin/bash devuser

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,89 @@
+name: Installation Matrix
+
+on:
+  push:
+    branches:
+      - main
+  # We don't run this for PRs as it is quite lengthy
+  # Instead, we can manually trigger the workflow for any branch
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install-run-ping:
+    name: Install/Run/Ping (${{ matrix.base }}, Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+        base: ["rocky8", "rocky9"]
+        include:
+          - base: rocky8
+            image_name: rockylinux:8
+          - base: rocky9
+            image_name: rockylinux:9
+          # RHEL is more complex (we need to build more packages ourselves) so we focus on Rocky for now
+          # - base: rhel8
+          #   image_name: redhat/ubi8:8.8
+
+    container:
+      image: ${{ matrix.image_name }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Install system dependencies
+        shell: bash
+        env:
+          PYTHON_VERSION: "${{ matrix.python-version }}"
+        run: .devcontainer/install.${{ matrix.base }}.sh
+
+      - name: Run make install
+        shell: bash
+        env:
+          PYTHON: "python${{ matrix.python-version }}"
+        run: make install
+
+      - name: Run make run in background
+        shell: bash
+        run: |
+          set -euo pipefail
+          make run > /tmp/warden-run.log 2>&1 &
+          echo $! > /tmp/warden-run.pid
+
+      - name: Sleep then ping local API
+        shell: bash
+        run: |
+          set -euo pipefail
+          sleep 5
+          curl --fail --silent --show-error http://localhost:8006
+
+      - name: Upload Warden logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # 7.0.1
+        if: always()
+        with:
+          name: warden-logs-${{ matrix.base }}-python-${{ matrix.python-version }}
+          path: logs/*.log
+
+      - name: Print run logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          echo "==== /tmp/warden-run.log ===="
+          test -f /tmp/warden-run.log && cat /tmp/warden-run.log || echo "No run log found"
+
+      - name: Stop background run
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if test -f /tmp/warden-run.pid; then
+            pid="$(cat /tmp/warden-run.pid)"
+            kill -TERM "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+          fi

--- a/config.mk
+++ b/config.mk
@@ -5,5 +5,5 @@
 WITH_PG=0
 WITH_MARIADB=0
 
-# The Python interpreter to use
-PYTHON=python3
+# The Python interpreter to use, 3.11 and 3.12 are supported
+PYTHON?=python3


### PR DESCRIPTION
Try installing and running Warden from scratch on the following environments:
- Rocky8, Rocky9
- Using python 3.11 and 3.12
Note: RHEL doesn't have all the packages available, but is mostly equivalent, so rocky8/9 should cover most of it