### PR TITLE
[FEAT] Introduce "authorized_user" list in config file for access management

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ The API server host and port are configurable through the YAML config or environ
 | `api.host` | `WARDEN_API_HOST` | API bind host address   | `0.0.0.0` | Yes      | `127.0.0.1`   |
 | `api.port` | `WARDEN_API_PORT` | API bind port           | `4207`    | Yes      | `8080`        |
 
+The API server can also be configured to only accept new jobs from configured user IDs:
+
+| Path       | Description             | Default   | Required | Example Value |
+|------------|-------------------------|-----------|----------|---------------|
+| `api.authorized_users` | List of user IDs auhorized to create new jobs  | `[]` | Yes      | `["1000", "2000", "0"]`   |
+
+The default value `[]` allows all users to create new jobs.
+
 ### Database
 
 Warden supports the following databases:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -9,14 +9,15 @@ from httpx import ASGITransport, AsyncClient
 
 from warden.api.app import create_app
 from warden.api.routes.dependencies.auth import MungeIdentity, munge_identity
-from warden.lib.config.config import Config, SqliteConfig
+from warden.lib.config.config import Config, SqliteConfig, UsersConfig
 from warden.lib.db.database import Base
 
 
 @pytest.fixture
 def config():
     db_config = SqliteConfig(name="warden_tests.db", backend="sqlite", echo=False)
-    yield Config(database=db_config)
+    users = UsersConfig(authorized_list=[])
+    yield Config(database=db_config, users=users)
 
 
 @pytest_asyncio.fixture

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -9,15 +9,15 @@ from httpx import ASGITransport, AsyncClient
 
 from warden.api.app import create_app
 from warden.api.routes.dependencies.auth import MungeIdentity, munge_identity
-from warden.lib.config.config import Config, SqliteConfig, UsersConfig
+from warden.lib.config.config import APIConfig, Config, SqliteConfig
 from warden.lib.db.database import Base
 
 
 @pytest.fixture
 def config():
     db_config = SqliteConfig(name="warden_tests.db", backend="sqlite", echo=False)
-    users = UsersConfig(authorized_list=[])
-    yield Config(database=db_config, users=users)
+    api = APIConfig(host="0.0.0.0", port=9999, authorized_users=[])
+    yield Config(database=db_config, api=api)
 
 
 @pytest_asyncio.fixture

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -28,3 +28,29 @@ async def test_create_session_no_auth(client):
     payload = {"user_id": "1000", "slurm_job_id": "1"}
     response = await client.post("/sessions", json=payload)
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_session_non_authorized_user(client, app):
+    """Creating a session using a non-authorized user when authorized_list is not empty"""
+    # Setting authorized user list
+    app.state.users_config.authorized_list = ["2000"]
+
+    payload = {"user_id": "1000", "slurm_job_id": "1"}
+    with mock_munge_auth(app, uid=0):
+        response = await client.post("/sessions", json=payload)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_session_authorized_user(client, app):
+    """Creating a session using an authorized user when authorized_list is not empty"""
+    # Setting authorized user list
+    app.state.users_config.authorized_list = ["1000"]
+
+    payload = {"user_id": "1000", "slurm_job_id": "1"}
+    with mock_munge_auth(app, uid=0):
+        response = await client.post("/sessions", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user_id"] == payload["user_id"]

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -32,9 +32,9 @@ async def test_create_session_no_auth(client):
 
 @pytest.mark.asyncio
 async def test_create_session_non_authorized_user(client, app):
-    """Creating a session using a non-authorized user when authorized_list is not empty"""
+    """Creating a session using a non-authorized user when authorized_users is not empty"""
     # Setting authorized user list
-    app.state.users_config.authorized_list = ["2000"]
+    app.state.authorized_users = ["2000"]
 
     payload = {"user_id": "1000", "slurm_job_id": "1"}
     with mock_munge_auth(app, uid=0):
@@ -44,9 +44,9 @@ async def test_create_session_non_authorized_user(client, app):
 
 @pytest.mark.asyncio
 async def test_create_session_authorized_user(client, app):
-    """Creating a session using an authorized user when authorized_list is not empty"""
+    """Creating a session using an authorized user when authorized_users is not empty"""
     # Setting authorized user list
-    app.state.users_config.authorized_list = ["1000"]
+    app.state.authorized_users = ["1000"]
 
     payload = {"user_id": "1000", "slurm_job_id": "1"}
     with mock_munge_auth(app, uid=0):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from warden.lib.config.config import Config, SchedulerConfig
-from warden.lib.config.config import SchedulerConfig, UsersConfig
+from warden.lib.config.config import APIConfig, Config, SchedulerConfig
 
 
 def test_scheduler():
@@ -29,24 +28,29 @@ def test_unprefixed_env_vars_do_not_override_config(monkeypatch, tmp_path):
     config = Config()
 
     assert config.api.host == "0.0.0.0"
-def test_authorized_list():
+
+
+def test_authorized_users():
     """
-    Test that authorized_list is a list of strings
+    Test that authorized_users is a list of strings
     coerced from user inputs
     """
-    config = UsersConfig(authorized_list=[1000, "2000"])
-    assert "1000" in config.authorized_list
-    assert "2000" in config.authorized_list
-    assert 1000 not in config.authorized_list
+    config = APIConfig(host="0.0.0.0", port=9999, authorized_users=[1000, "2000"])
+    assert "1000" in config.authorized_users
+    assert "2000" in config.authorized_users
+    assert 1000 not in config.authorized_users
 
 
-def test_authorized_list_wrong_input():
+def test_authorized_users_wrong_input():
     """
-    Test that authorized_list is a list of strings
+    Test that authorized_users is a list of strings
     coerced from user inputs that must be either strings or integers
+
+    1. Test list input error
+    2. Test float input error
     """
     with pytest.raises(ValidationError):
-        UsersConfig(authorized_list=[[]])
+        APIConfig(host="0.0.0.0", port=9999, authorized_users=[[]])
 
     with pytest.raises(ValidationError):
-        UsersConfig(authorized_list=[1.0])
+        APIConfig(host="0.0.0.0", port=9999, authorized_users=[1.0])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,10 @@ import pytest
 from pydantic import ValidationError
 
 from warden.lib.config.config import Config, SchedulerConfig
+from warden.lib.config.config import SchedulerConfig, UsersConfig
 
 
-def test_scheduler_config():
+def test_scheduler():
     with pytest.raises(ValidationError):
         SchedulerConfig(strategy="NOT_FIFO", db_polling_interval_s=1)
 
@@ -28,3 +29,24 @@ def test_unprefixed_env_vars_do_not_override_config(monkeypatch, tmp_path):
     config = Config()
 
     assert config.api.host == "0.0.0.0"
+def test_authorized_list():
+    """
+    Test that authorized_list is a list of strings
+    coerced from user inputs
+    """
+    config = UsersConfig(authorized_list=[1000, "2000"])
+    assert "1000" in config.authorized_list
+    assert "2000" in config.authorized_list
+    assert 1000 not in config.authorized_list
+
+
+def test_authorized_list_wrong_input():
+    """
+    Test that authorized_list is a list of strings
+    coerced from user inputs that must be either strings or integers
+    """
+    with pytest.raises(ValidationError):
+        UsersConfig(authorized_list=[[]])
+
+    with pytest.raises(ValidationError):
+        UsersConfig(authorized_list=[1.0])

--- a/warden/api/app.py
+++ b/warden/api/app.py
@@ -3,9 +3,9 @@ import logging
 from fastapi import FastAPI
 
 from warden.api.routes import accessible, jobs, qpu, sessions
+from warden.api.routes.dependencies.authorized_users import init_authorized_users
 from warden.api.routes.dependencies.db import init_db
 from warden.api.routes.dependencies.qpu_client import init_qpu_client
-from warden.api.routes.dependencies.authorized_users import init_authorized_users
 from warden.lib.config import Config
 
 

--- a/warden/api/app.py
+++ b/warden/api/app.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from warden.api.routes import accessible, jobs, qpu, sessions
 from warden.api.routes.dependencies.db import init_db
 from warden.api.routes.dependencies.qpu_client import init_qpu_client
-from warden.api.routes.dependencies.users import init_authorized_users
+from warden.api.routes.dependencies.authorized_users import init_authorized_users
 from warden.lib.config import Config
 
 
@@ -17,7 +17,7 @@ def create_app(config: Config):
     )
     init_db(app, config.database)
     init_qpu_client(app, config.qpu)
-    init_authorized_users(app, config.api)
+    init_authorized_users(app, config.api.authorized_users)
 
     app.include_router(jobs.router, tags=["jobs"])
     app.include_router(sessions.router, tags=["sessions"])

--- a/warden/api/app.py
+++ b/warden/api/app.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from warden.api.routes import accessible, jobs, qpu, sessions
 from warden.api.routes.dependencies.db import init_db
 from warden.api.routes.dependencies.qpu_client import init_qpu_client
-from warden.api.routes.dependencies.users import init_users
+from warden.api.routes.dependencies.users import init_authorized_users
 from warden.lib.config import Config
 
 
@@ -17,7 +17,7 @@ def create_app(config: Config):
     )
     init_db(app, config.database)
     init_qpu_client(app, config.qpu)
-    init_users(app, config.users)
+    init_authorized_users(app, config.api)
 
     app.include_router(jobs.router, tags=["jobs"])
     app.include_router(sessions.router, tags=["sessions"])

--- a/warden/api/app.py
+++ b/warden/api/app.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from warden.api.routes import accessible, jobs, qpu, sessions
 from warden.api.routes.dependencies.db import init_db
 from warden.api.routes.dependencies.qpu_client import init_qpu_client
+from warden.api.routes.dependencies.users import init_users
 from warden.lib.config import Config
 
 
@@ -16,6 +17,7 @@ def create_app(config: Config):
     )
     init_db(app, config.database)
     init_qpu_client(app, config.qpu)
+    init_users(app, config.users)
 
     app.include_router(jobs.router, tags=["jobs"])
     app.include_router(sessions.router, tags=["sessions"])

--- a/warden/api/routes/dependencies/authorized_users.py
+++ b/warden/api/routes/dependencies/authorized_users.py
@@ -5,11 +5,11 @@ from fastapi import Depends, FastAPI, Request
 from warden.lib.config import APIConfig
 
 
-def init_authorized_users(app: FastAPI, api_config: APIConfig):
-    app.state.authorized_users = api_config.authorized_users
+def init_authorized_users(app: FastAPI, authorized_users: list[str]):
+    app.state.authorized_users = authorized_users
 
 
-def get_authorized_users(request: Request) -> APIConfig:
+def get_authorized_users(request: Request) -> list[str]:
     conf = getattr(request.app.state, "authorized_users", None)
     if conf is None:
         raise RuntimeError(

--- a/warden/api/routes/dependencies/users.py
+++ b/warden/api/routes/dependencies/users.py
@@ -2,20 +2,20 @@ from typing import Annotated
 
 from fastapi import Depends, FastAPI, Request
 
-from warden.lib.config import UsersConfig
+from warden.lib.config import APIConfig
 
 
-def init_users(app: FastAPI, user_config: UsersConfig):
-    app.state.users_config = user_config
+def init_authorized_users(app: FastAPI, api_config: APIConfig):
+    app.state.authorized_users = api_config.authorized_users
 
 
-def get_config(request: Request) -> UsersConfig:
-    conf = getattr(request.app.state, "users_config", None)
+def get_authorized_users(request: Request) -> APIConfig:
+    conf = getattr(request.app.state, "authorized_users", None)
     if conf is None:
         raise RuntimeError(
-            "Config not initialized. init_users(app, ...) was not called."
+            "Config not initialized. init_authorized_users(app, ...) was not called."
         )
     return conf
 
 
-UsersConfigDep = Annotated[UsersConfig, Depends(get_config)]
+AuthorizedUsersDep = Annotated[APIConfig, Depends(get_authorized_users)]

--- a/warden/api/routes/dependencies/users.py
+++ b/warden/api/routes/dependencies/users.py
@@ -1,0 +1,21 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Request
+
+from warden.lib.config import UsersConfig
+
+
+def init_users(app: FastAPI, user_config: UsersConfig):
+    app.state.users_config = user_config
+
+
+def get_config(request: Request) -> UsersConfig:
+    conf = getattr(request.app.state, "users_config", None)
+    if conf is None:
+        raise RuntimeError(
+            "Config not initialized. init_users(app, ...) was not called."
+        )
+    return conf
+
+
+UsersConfigDep = Annotated[UsersConfig, Depends(get_config)]

--- a/warden/api/routes/sessions.py
+++ b/warden/api/routes/sessions.py
@@ -7,7 +7,7 @@ from sqlalchemy import Select
 
 from warden.api.routes.dependencies.auth import verify_root
 from warden.api.routes.dependencies.db import DBSessionDep
-from warden.api.routes.dependencies.users import UsersConfigDep
+from warden.api.routes.dependencies.users import AuthorizedUsersDep
 from warden.api.schemas.sessions import CreateSession, SessionResponse
 from warden.lib.models.sessions import Session
 
@@ -19,13 +19,11 @@ router = APIRouter(prefix="/sessions")
 async def create_session(
     payload: CreateSession,
     db_session: DBSessionDep,
-    users_conf: UsersConfigDep,
+    authorized_users: AuthorizedUsersDep,
     _=Depends(verify_root),
 ) -> SessionResponse:
-    if (
-        users_conf.authorized_list != []
-        and payload.user_id not in users_conf.authorized_list
-    ):
+    if authorized_users != [] and payload.user_id not in authorized_users:
+        logger.info(f"Unauthorized user: {payload.user_id} attempting to create a session.")
         raise HTTPException(status_code=403, detail="User ID not authorized.")
     new_session = Session(
         user_id=str(payload.user_id),

--- a/warden/api/routes/sessions.py
+++ b/warden/api/routes/sessions.py
@@ -6,8 +6,8 @@ from pydantic import UUID4
 from sqlalchemy import Select
 
 from warden.api.routes.dependencies.auth import verify_root
-from warden.api.routes.dependencies.db import DBSessionDep
 from warden.api.routes.dependencies.authorized_users import AuthorizedUsersDep
+from warden.api.routes.dependencies.db import DBSessionDep
 from warden.api.schemas.sessions import CreateSession, SessionResponse
 from warden.lib.models.sessions import Session
 

--- a/warden/api/routes/sessions.py
+++ b/warden/api/routes/sessions.py
@@ -23,7 +23,9 @@ async def create_session(
     _=Depends(verify_root),
 ) -> SessionResponse:
     if authorized_users != [] and payload.user_id not in authorized_users:
-        logger.info(f"Unauthorized user: {payload.user_id} attempting to create a session.")
+        logger.info(
+            f"Unauthorized user: {payload.user_id} attempting to create a session."
+        )
         raise HTTPException(status_code=403, detail="User ID not authorized.")
     new_session = Session(
         user_id=str(payload.user_id),

--- a/warden/api/routes/sessions.py
+++ b/warden/api/routes/sessions.py
@@ -7,7 +7,7 @@ from sqlalchemy import Select
 
 from warden.api.routes.dependencies.auth import verify_root
 from warden.api.routes.dependencies.db import DBSessionDep
-from warden.api.routes.dependencies.users import AuthorizedUsersDep
+from warden.api.routes.dependencies.authorized_users import AuthorizedUsersDep
 from warden.api.schemas.sessions import CreateSession, SessionResponse
 from warden.lib.models.sessions import Session
 

--- a/warden/api/routes/sessions.py
+++ b/warden/api/routes/sessions.py
@@ -7,6 +7,7 @@ from sqlalchemy import Select
 
 from warden.api.routes.dependencies.auth import verify_root
 from warden.api.routes.dependencies.db import DBSessionDep
+from warden.api.routes.dependencies.users import UsersConfigDep
 from warden.api.schemas.sessions import CreateSession, SessionResponse
 from warden.lib.models.sessions import Session
 
@@ -18,8 +19,14 @@ router = APIRouter(prefix="/sessions")
 async def create_session(
     payload: CreateSession,
     db_session: DBSessionDep,
+    users_conf: UsersConfigDep,
     _=Depends(verify_root),
 ) -> SessionResponse:
+    if (
+        users_conf.authorized_list != []
+        and payload.user_id not in users_conf.authorized_list
+    ):
+        raise HTTPException(status_code=403, detail="User ID not authorized.")
     new_session = Session(
         user_id=str(payload.user_id),
         slurm_job_id=payload.slurm_job_id,

--- a/warden/lib/config/__init__.py
+++ b/warden/lib/config/__init__.py
@@ -1,3 +1,9 @@
-from warden.lib.config.config import Config, DatabaseConfig, QPUConfig, SchedulerConfig
+from warden.lib.config.config import (
+    Config,
+    DatabaseConfig,
+    QPUConfig,
+    SchedulerConfig,
+    UsersConfig,
+)
 
-__all__ = ["Config", "DatabaseConfig", "QPUConfig", "SchedulerConfig"]
+__all__ = ["Config", "DatabaseConfig", "QPUConfig", "SchedulerConfig", "UsersConfig"]

--- a/warden/lib/config/__init__.py
+++ b/warden/lib/config/__init__.py
@@ -1,9 +1,9 @@
 from warden.lib.config.config import (
+    APIConfig,
     Config,
     DatabaseConfig,
     QPUConfig,
     SchedulerConfig,
-    UsersConfig,
 )
 
-__all__ = ["Config", "DatabaseConfig", "QPUConfig", "SchedulerConfig", "UsersConfig"]
+__all__ = ["Config", "DatabaseConfig", "QPUConfig", "SchedulerConfig", "APIConfig"]

--- a/warden/lib/config/config.py
+++ b/warden/lib/config/config.py
@@ -5,8 +5,7 @@ from typing import Annotated, Any, Literal
 
 import httpx
 import yaml
-from pydantic import Field, PrivateAttr, model_validator
-from pydantic import BeforeValidator, Field, PrivateAttr
+from pydantic import BeforeValidator, Field, PrivateAttr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 API_PREFIX = "/api/v1"
@@ -69,10 +68,6 @@ class QPUConfig(BaseSettings):
         return self._client
 
 
-class APIConfig(BaseSettings):
-    host: str
-    port: int
-
 def coerce_to_str(v):
     for item in v:
         if type(item) not in (str, int):
@@ -80,9 +75,11 @@ def coerce_to_str(v):
     return [str(item) for item in v]
 
 
-class UsersConfig(BaseSettings):
-    # processing authorized_list as strings but allowing users to input numbers
-    authorized_list: Annotated[list[str], BeforeValidator(coerce_to_str)]
+class APIConfig(BaseSettings):
+    host: str
+    port: int
+    # processing authorized_users as strings but allowing users to input numbers
+    authorized_users: Annotated[list[str], BeforeValidator(coerce_to_str)]
 
 
 class Config(BaseSettings):
@@ -91,7 +88,6 @@ class Config(BaseSettings):
     scheduler: SchedulerConfig
     logging: dict[str, Any]
     qpu: QPUConfig
-    users: UsersConfig
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/warden/lib/config/config.py
+++ b/warden/lib/config/config.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Literal
 import httpx
 import yaml
 from pydantic import Field, PrivateAttr, model_validator
+from pydantic import BeforeValidator, Field, PrivateAttr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 API_PREFIX = "/api/v1"
@@ -72,8 +73,16 @@ class APIConfig(BaseSettings):
     host: str
     port: int
 
+def coerce_to_str(v):
+    for item in v:
+        if type(item) not in (str, int):
+            raise ValueError("User uid must be a string or an integer")
+    return [str(item) for item in v]
+
+
 class UsersConfig(BaseSettings):
-    authorized_list: list[str] = Field(default=[])
+    # processing authorized_list as strings but allowing users to input numbers
+    authorized_list: Annotated[list[str], BeforeValidator(coerce_to_str)]
 
 
 class Config(BaseSettings):

--- a/warden/lib/config/config.py
+++ b/warden/lib/config/config.py
@@ -72,6 +72,9 @@ class APIConfig(BaseSettings):
     host: str
     port: int
 
+class UsersConfig(BaseSettings):
+    authorized_list: list[str] = Field(default=[])
+
 
 class Config(BaseSettings):
     api: APIConfig
@@ -79,6 +82,7 @@ class Config(BaseSettings):
     scheduler: SchedulerConfig
     logging: dict[str, Any]
     qpu: QPUConfig
+    users: UsersConfig
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/warden/lib/config/config.sample.yaml
+++ b/warden/lib/config/config.sample.yaml
@@ -3,6 +3,10 @@ api:
   host: 0.0.0.0
   # API bind port
   port: 4207
+  # List of user id authorized to create new jobs on the QPU by creating a new session.
+  # Must be list of strings or integers.
+  # If userlist is empty, all users are authorized.
+  authorized_users: []
 
 database:
   # echo: false # Optional, SQLAlchemy echo
@@ -70,11 +74,6 @@ qpu:
   retry_max: 10
   # Time between request retries
   retry_sleep_s: 1
-
-users:
-  # List of user id authorized to access Warden, must be list of strings or integers.
-  # If userlist is empty, all users are authorized.
-  authorized_list: []
 
 logging:
   version: 1

--- a/warden/lib/config/config.sample.yaml
+++ b/warden/lib/config/config.sample.yaml
@@ -71,6 +71,11 @@ qpu:
   # Time between request retries
   retry_sleep_s: 1
 
+users:
+  # List of users authorized to access Warden
+  # If userlist is empty, all users are authorized.
+  authorized_list: []
+
 logging:
   version: 1
   disable_existing_loggers: false

--- a/warden/lib/config/config.sample.yaml
+++ b/warden/lib/config/config.sample.yaml
@@ -72,7 +72,7 @@ qpu:
   retry_sleep_s: 1
 
 users:
-  # List of users authorized to access Warden
+  # List of user id authorized to access Warden, must be list of strings or integers.
   # If userlist is empty, all users are authorized.
   authorized_list: []
 


### PR DESCRIPTION
# Authorized user

For compliance, we need a mechanism to allow sysadmins to filter users allowed to run jobs through warden

## Added

- A `users` configuration section with a `authorized_list` filed to store authorized user IDs
  - If list is empty, all users are allowed
  - Else, users not in the list get a `403` error during session creation
  - Inputs can be integers or strings