### PR TITLE
fix: Change Warden default qpu uri

### DIFF
--- a/warden/lib/config/config.sample.yaml
+++ b/warden/lib/config/config.sample.yaml
@@ -66,7 +66,7 @@ scheduler:
 
 qpu:
   # Local Pasqal QPU API configuration
-  uri: http://localhost:8005
+  uri: http://localhost:8000
 
   # Request retry policy
   # Max number of retries to the QPU API in case of 


### PR DESCRIPTION
By default, the mock QPU is using port 8000 (when running `make start-mock-qpu`)

The default config of Warden now targets `localhost:8000` to reflect this.