### PR TITLE
Fix `Job` db model and typing issues

### DIFF
--- a/warden/api/routes/jobs.py
+++ b/warden/api/routes/jobs.py
@@ -39,7 +39,7 @@ async def list_jobs(
     session: DBSessionDep,
     identity: MungeIdentity = Depends(munge_identity),
 ) -> list[JobResponse]:
-    result = await session.execute(select(Job).where(Job.user_id == identity.uid))
+    result = await session.execute(select(Job).where(Job.user_id == str(identity.uid)))
     jobs = result.scalars().all()
 
     return [JobResponse.from_model(job) for job in jobs]
@@ -52,7 +52,7 @@ async def get_job(
     identity: MungeIdentity = Depends(munge_identity),
 ) -> JobResponse:
     result = await session.execute(
-        select(Job).where(Job.user_id == identity.uid, Job.id == id)
+        select(Job).where(Job.user_id == str(identity.uid), Job.id == id)
     )
     job = result.scalars().one_or_none()
     if job is None:

--- a/warden/lib/models/jobs.py
+++ b/warden/lib/models/jobs.py
@@ -40,11 +40,6 @@ class Job(Base):
         nullable=True,
         doc="Datetime when the job's processing was over.",
     )
-    user_id: Mapped[str] = mapped_column(
-        String(255),
-        nullable=False,
-        doc="ID of the user who submitted the job.",
-    )
     status: Mapped[str] = mapped_column(
         String(50),
         nullable=False,
@@ -76,7 +71,7 @@ class Job(Base):
     )
     session: Mapped[Session] = relationship("Session", lazy="joined")
 
-    user_id: AssociationProxy[UUID] = association_proxy(
+    user_id: AssociationProxy[str] = association_proxy(
         "session",
         "user_id",
     )


### PR DESCRIPTION
# Description

Removes duplicate `user_id` definition in `Job` table and correctly fixes the `AssossiationProxy` to a `string` instead of a `UUID` 

# Closes 

#44 