### PR TITLE
Fix return type of mock results

### DIFF
--- a/tests/mock_qpu_api/samples.py
+++ b/tests/mock_qpu_api/samples.py
@@ -1,3 +1,5 @@
+import json
+
 DUMMY_QPU_SPECS = {
     "name": "FRESNEL",
     "dimensions": 2,
@@ -65,6 +67,7 @@ DUMMY_QPU_SPECS = {
     ],
     "is_virtual": False,
 }
-FAKE_RESULTS = str(
+# PasqOS returns a "StringDictField" in the same way
+FAKE_RESULTS = json.dumps(
     {"counter": {"0000": 477, "0010": 3, "0110": 1, "0001": 8, "0100": 7, "1000": 4}}
 )


### PR DESCRIPTION
Fixing return type of the mock qpu API

Doesn't match type returned from Pasqos (StringDictField) and couldn't be correctly json loaded.

Needed for review of @awennersteen QRMI PR 