### PR TITLE
Tb/fix pip version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ include config.mk dev.mk
 .PHONY: start-mock-qpu start-qutip-qpu
 
 VENV=.venv
+PIP_VERSION ?= 26
 ifeq ($(WITH_PG),1)
 INSTALL_FLAGS  += -r requirements-pg.txt
 endif
@@ -59,6 +60,7 @@ $(VENV)/bin/python: config.yaml
 	fi
 
 install: $(VENV)/bin/python
+	$(VENV)/bin/python -m pip install -U pip==$(PIP_VERSION)
 	$(VENV)/bin/python -m pip install -r requirements.txt $(INSTALL_FLAGS)
 
 run: migrate

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include config.mk dev.mk
 .PHONY: start-mock-qpu start-qutip-qpu
 
 VENV=.venv
-PIP_VERSION ?= 26
+PIP_VERSION ?= 26.1
 ifeq ($(WITH_PG),1)
 INSTALL_FLAGS  += -r requirements-pg.txt
 endif
@@ -56,11 +56,12 @@ $(VENV)/bin/python: config.yaml
 	else \
 		echo "Creating $(VENV) with $(PYTHON)"; \
 		$(PYTHON) -m venv --copies $(VENV); \
+		echo "Installing pip $(PIP_VERSION) in $(VENV)"; \
+		$(VENV)/bin/python -m pip install -U 'pip~=$(PIP_VERSION)'
 		echo "Virtualenv created in $(VENV) using $(PYTHON)"; \
 	fi
 
 install: $(VENV)/bin/python
-	$(VENV)/bin/python -m pip install -U pip==$(PIP_VERSION)
 	$(VENV)/bin/python -m pip install -r requirements.txt $(INSTALL_FLAGS)
 
 run: migrate

--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,9 @@ $(VENV)/bin/python: config.yaml
 	else \
 		echo "Creating $(VENV) with $(PYTHON)"; \
 		$(PYTHON) -m venv --copies $(VENV); \
-		echo "Installing pip $(PIP_VERSION) in $(VENV)"; \
-		$(VENV)/bin/python -m pip install -U pip~=$(PIP_VERSION); \ 
 		echo "Virtualenv created in $(VENV) using $(PYTHON)"; \
 	fi
+	$(VENV)/bin/python -m pip install -U pip~=$(PIP_VERSION)
 
 install: $(VENV)/bin/python
 	$(VENV)/bin/python -m pip install -r requirements.txt $(INSTALL_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ $(VENV)/bin/python: config.yaml
 		echo "Creating $(VENV) with $(PYTHON)"; \
 		$(PYTHON) -m venv --copies $(VENV); \
 		echo "Installing pip $(PIP_VERSION) in $(VENV)"; \
-		$(VENV)/bin/python -m pip install -U 'pip~=$(PIP_VERSION)'
+		$(VENV)/bin/python -m pip install -U pip~=$(PIP_VERSION); \ 
 		echo "Virtualenv created in $(VENV) using $(PYTHON)"; \
 	fi
 


### PR DESCRIPTION
Fixes the following install errors that happen with old pip versions (~23) by updating pip version to ~26.1

<img width="1756" height="76" alt="image" src="https://github.com/user-attachments/assets/ec4b0bcc-1c1a-4297-9cf1-e0cd9c243121" />

Apparently cause by a transitive dependency of `auth0-python` that is not correctly pinned @sarjevane.

Here we fix it by setting the pip version at venv creation time.

We could also update pip at installation time ?