### PR TITLE
Accounting endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ The default value `[]` for `api.authorized_users` allows all users to create new
 included in `api.admin_users`; otherwise the plugin cannot acquire a session and
 Warden is unusable with it.
 
+### Accounting API
+
+Warden exposes usage-reporting endpoints under `/accounting`, restricted to
+`api.admin_users`:
+
+| Route                | Description                                          |
+|-----------------------|-------------------------------------------------------|
+| `GET /accounting`          | Per-user summary of sessions and jobs             |
+| `GET /accounting/sessions` | Per-session detail 
+| `GET /accounting/jobs`     | Per-job detail
+
+All three accept `start_datetime` (required), `end_datetime`, `user_ids` and
+pagination (`limit`, `offset`) as query parameters, and filter on session
+`revoked_at`. `GET /accounting/sessions` additionally accepts `slurm_job_id` filtering,
+and `GET /accounting/jobs` accepts `session_id` and `status` filtering.
+
+See FastAPI's `/docs` page for the full request/response schema of each
+route.
+
 ### Database
 
 Warden supports the following databases:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -260,6 +260,8 @@ async def acct_populate_db(
     session_duration: timedelta = timedelta(hours=1),
     user_time_offset: timedelta = timedelta(hours=1),
     job_statuses: Sequence[str] = ("DONE",),
+    job_wait_time: timedelta = timedelta(seconds=15),
+    job_execution_time: timedelta = timedelta(seconds=45),
 ) -> tuple[list[str], list[Job], list[Session]]:
     """Creates mock data for accounting testing in DB
 
@@ -275,13 +277,17 @@ async def acct_populate_db(
     sessions = []
     jobs = []
     for i, uid in enumerate(user_uids):
-        start_session = BASE_START_DATETIME + i * user_time_offset
-        end_session = BASE_END_DATETIME + i * user_time_offset
+        session_start = BASE_START_DATETIME + i * user_time_offset
+        session_end = BASE_END_DATETIME + i * user_time_offset
+
+        job_created = session_start
+        job_started = session_start + job_wait_time
+        job_ended = job_started + job_execution_time
 
         sessions.append(
             Session(
-                created_at=start_session,
-                revoked_at=end_session,
+                created_at=session_start,
+                revoked_at=session_end,
                 user_id=uid,
                 slurm_job_id=str(i),
             )
@@ -293,10 +299,10 @@ async def acct_populate_db(
                     logs="",
                     shots=100,
                     sequence="",
-                    created_at=start_session,
-                    scheduled_at=start_session,
-                    started_at=start_session,
-                    ended_at=end_session,
+                    created_at=job_created,
+                    scheduled_at=job_started,
+                    started_at=job_started,
+                    ended_at=job_ended,
                     # Relationship
                     session=sessions[-1],
                 )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -255,7 +255,6 @@ def qpu_specs() -> dict:
 
 async def acct_populate_db(
     app,
-    serialized_sequence: str,
     n_users: int,
     first_session_start: datetime = datetime(2026, 1, 1, 0, 0, 0),
     session_duration: timedelta = timedelta(hours=1),
@@ -264,7 +263,7 @@ async def acct_populate_db(
 ) -> tuple[list[str], list[Job], list[Session]]:
     """Creates mock data for accounting testing in DB
 
-    One session per user, and one job per entry in ``job_statuses`` per user.
+    One session per user, and one job per entry in `job_statuses` per user.
     Passing several statuses makes the jobs aggregation produce more rows than
     the sessions aggregation, which is what exercises their pagination.
     """
@@ -293,7 +292,7 @@ async def acct_populate_db(
                     status=status,
                     logs="",
                     shots=100,
-                    sequence=serialized_sequence,
+                    sequence="",
                     created_at=start_session,
                     scheduled_at=start_session,
                     started_at=start_session,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -270,7 +270,7 @@ async def acct_populate_db(
     """
     BASE_START_DATETIME = first_session_start
     BASE_END_DATETIME = BASE_START_DATETIME + session_duration
-    user_uids = [str(i) for i in range(1000, 1000 + n_users)]
+    user_uids = [str(i) for i in range(9000, 9000 + n_users)]
 
     # Create at least one session and job per user
     sessions = []

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,5 +1,6 @@
 import json
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 from typing import AsyncGenerator, Callable, Generator
 
 import pytest
@@ -13,6 +14,7 @@ from warden.api.routes.dependencies.auth import MungeIdentity, munge_identity
 from warden.api.routes.dependencies.qpu_client import get_qpu_client
 from warden.lib.config.config import APIConfig, Config, DatabaseConfig, QPUConfig
 from warden.lib.db.database import Base
+from warden.lib.models import Job, Session
 from warden.lib.qpu_client.client import AsyncQPUClient
 
 
@@ -249,3 +251,54 @@ def qpu_specs() -> dict:
     specs = json.loads(DigitalAnalogDevice.to_abstract_repr())
     specs["name"] = "FRESNEL_CAN1"
     return specs
+
+
+async def acct_populate_db(
+    app,
+    serialized_sequence: str,
+    n_users: int,
+    first_session_start: datetime = datetime(2026, 1, 1, 0, 0, 0),
+    session_duration: timedelta = timedelta(hours=1),
+    user_time_offset: timedelta = timedelta(hours=1),
+) -> tuple[list[str], list[Job], list[Session]]:
+    """Creates mock data for accounting testing in DB"""
+    BASE_START_DATETIME = first_session_start
+    BASE_END_DATETIME = BASE_START_DATETIME + session_duration
+    user_uids = [str(i) for i in range(1000, 1000 + n_users)]
+
+    # Create at least one session and job per user
+    sessions = []
+    jobs = []
+    for i, uid in enumerate(user_uids):
+        start_session = BASE_START_DATETIME + i * user_time_offset
+        end_session = BASE_END_DATETIME + i * user_time_offset
+
+        sessions.append(
+            Session(
+                created_at=start_session,
+                revoked_at=end_session,
+                user_id=uid,
+                slurm_job_id=str(i),
+            )
+        )
+        jobs.append(
+            Job(
+                status="DONE",
+                logs="",
+                shots=100,
+                sequence=serialized_sequence,
+                created_at=start_session,
+                scheduled_at=start_session,
+                started_at=start_session,
+                ended_at=end_session,
+                # Relationship
+                session=sessions[-1],
+            )
+        )
+
+    async_session_factory = app.state.db_session_factory
+    async with async_session_factory() as db_session:
+        db_session.add_all(sessions)
+        db_session.add_all(jobs)
+        await db_session.commit()
+    return user_uids, jobs, sessions

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import contextmanager
 from datetime import datetime, timedelta
-from typing import AsyncGenerator, Callable, Generator
+from typing import AsyncGenerator, Callable, Generator, Sequence
 
 import pytest
 import pytest_asyncio
@@ -260,8 +260,14 @@ async def acct_populate_db(
     first_session_start: datetime = datetime(2026, 1, 1, 0, 0, 0),
     session_duration: timedelta = timedelta(hours=1),
     user_time_offset: timedelta = timedelta(hours=1),
+    job_statuses: Sequence[str] = ("DONE",),
 ) -> tuple[list[str], list[Job], list[Session]]:
-    """Creates mock data for accounting testing in DB"""
+    """Creates mock data for accounting testing in DB
+
+    One session per user, and one job per entry in ``job_statuses`` per user.
+    Passing several statuses makes the jobs aggregation produce more rows than
+    the sessions aggregation, which is what exercises their pagination.
+    """
     BASE_START_DATETIME = first_session_start
     BASE_END_DATETIME = BASE_START_DATETIME + session_duration
     user_uids = [str(i) for i in range(1000, 1000 + n_users)]
@@ -281,20 +287,21 @@ async def acct_populate_db(
                 slurm_job_id=str(i),
             )
         )
-        jobs.append(
-            Job(
-                status="DONE",
-                logs="",
-                shots=100,
-                sequence=serialized_sequence,
-                created_at=start_session,
-                scheduled_at=start_session,
-                started_at=start_session,
-                ended_at=end_session,
-                # Relationship
-                session=sessions[-1],
+        for status in job_statuses:
+            jobs.append(
+                Job(
+                    status=status,
+                    logs="",
+                    shots=100,
+                    sequence=serialized_sequence,
+                    created_at=start_session,
+                    scheduled_at=start_session,
+                    started_at=start_session,
+                    ended_at=end_session,
+                    # Relationship
+                    session=sessions[-1],
+                )
             )
-        )
 
     async_session_factory = app.state.db_session_factory
     async with async_session_factory() as db_session:

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -6,6 +6,8 @@ from httpx import AsyncClient
 from tests.api.conftest import acct_populate_db, mock_munge_auth
 
 ACCT_ENDPOINT = "/accounting"
+ACCT_SESSIONS_ENDPOINT = "/accounting/sessions"
+ACCT_JOBS_ENDPOINT = "/accounting/jobs"
 
 
 @pytest.mark.asyncio
@@ -318,3 +320,124 @@ async def test_acct_user_filtering(client, app, serialized_sequence):
 
     data = response.json()["data"]
     assert len(data) == 0
+
+
+@pytest.mark.asyncio
+async def test_acct_jobs_user_filtering(client, app, serialized_sequence):
+    """Assert that /accounting/jobs filters by user and reports the right count."""
+    N_USERS = 3
+    JOB_STATUSES = ("DONE", "ERROR")
+
+    user_uids, _, _ = await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        job_statuses=JOB_STATUSES,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_JOBS_ENDPOINT
+            + "?start_datetime=2020-01-01T00:00:00"
+            + f"&user_ids={user_uids[0]}"
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == len(JOB_STATUSES)
+    assert len(body["data"]) == len(JOB_STATUSES)
+    assert all(job["user_id"] == user_uids[0] for job in body["data"])
+
+
+@pytest.mark.asyncio
+async def test_acct_jobs_session_id_filtering(client, app, serialized_sequence):
+    """Assert that /accounting/jobs can be filtered by session_id."""
+    N_USERS = 2
+    JOB_STATUSES = ("DONE", "ERROR")
+
+    _, _, sessions = await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        job_statuses=JOB_STATUSES,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_JOBS_ENDPOINT
+            + "?start_datetime=2020-01-01T00:00:00"
+            + f"&session_id={sessions[0].id}"
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == len(JOB_STATUSES)
+    assert len(body["data"]) == len(JOB_STATUSES)
+    assert all(job["session_id"] == str(sessions[0].id) for job in body["data"])
+
+
+@pytest.mark.asyncio
+async def test_acct_sessions_nominal(client, app, serialized_sequence):
+    """Assert that /accounting/sessions lists one row per session with its
+    own duration and job count."""
+    N_USERS = 4
+    JOB_STATUSES = ("DONE", "ERROR")
+    SESSION_DURATION = timedelta(minutes=30)
+
+    user_uids, _, sessions = await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        session_duration=SESSION_DURATION,
+        job_statuses=JOB_STATUSES,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_SESSIONS_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == N_USERS
+    assert len(body["data"]) == N_USERS
+
+    expected_duration = int(SESSION_DURATION.total_seconds())
+    for i, session_data in enumerate(body["data"]):
+        assert session_data["id"] == str(sessions[i].id)
+        assert session_data["user_id"] == user_uids[i]
+        assert session_data["total_duration"] == expected_duration
+        assert session_data["jobs_count"] == len(JOB_STATUSES)
+
+
+@pytest.mark.asyncio
+async def test_acct_jobs_nominal(client, app, serialized_sequence):
+    """Assert that /accounting/jobs lists one row per job with its own
+    status and durations."""
+    N_USERS = 2
+    SESSION_DURATION = timedelta(minutes=20)
+
+    user_uids, jobs, _ = await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        session_duration=SESSION_DURATION,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_JOBS_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == N_USERS
+    assert len(body["data"]) == N_USERS
+
+    expected_execution_time = int(SESSION_DURATION.total_seconds())
+    for i, job_data in enumerate(body["data"]):
+        assert job_data["id"] == jobs[i].id
+        assert job_data["user_id"] == user_uids[i]
+        assert job_data["status"] == "DONE"
+        assert job_data["execution_time"] == expected_execution_time
+        assert job_data["wait_time"] == 0

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -4,11 +4,45 @@ from urllib.parse import quote
 import pytest
 
 from tests.api.conftest import acct_populate_db, mock_munge_auth
+from warden.api.schemas.acct import AcctRequest
 
 ACCT_ENDPOINT = "/accounting"
 ACCT_SESSIONS_ENDPOINT = "/accounting/sessions"
 ACCT_JOBS_ENDPOINT = "/accounting/jobs"
 ACCT_ENDPOINTS = [ACCT_ENDPOINT, ACCT_JOBS_ENDPOINT, ACCT_SESSIONS_ENDPOINT]
+
+###############################################################################
+############################### ACCT QUERY TESTS ##############################
+###############################################################################
+
+
+def test_acct_request_normalizes_datetimes_to_utc():
+    """The `start_datetime`/`end_datetime` validator must produce UTC-aware
+    values regardless of the offset supplied by the caller, since not every
+    supported DB backend preserves timezone info on stored columns."""
+
+    naive_utc = datetime(2026, 1, 1, 12, 0, 0)
+    aware_utc = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    aware_non_utc = naive_utc.replace(tzinfo=timezone(timedelta(hours=2))) + timedelta(
+        hours=2
+    )
+
+    req = AcctRequest(start_datetime=aware_non_utc, end_datetime=aware_non_utc)
+    assert req.start_datetime == aware_utc
+    assert req.end_datetime == aware_utc
+
+    # Naive input is assumed to already be UTC and passed through unchanged.
+    req_naive = AcctRequest(start_datetime=naive_utc)
+    assert req_naive.start_datetime == aware_utc
+    assert req_naive.start_datetime.tzinfo is timezone.utc
+
+    # end_datetime is optional; None must pass through untouched.
+    assert req_naive.end_datetime is None
+
+
+###############################################################################
+############################## COMMON ROUTE TESTS #############################
+###############################################################################
 
 
 @pytest.mark.asyncio
@@ -80,8 +114,64 @@ async def test_acct_pagination(
 
 
 @pytest.mark.asyncio
-async def test_acct_datetime_filter(client, app):
-    """Assert that the accounting data query correctly filters according to start/end datetime."""
+@pytest.mark.parametrize("endpoint", ACCT_ENDPOINTS)
+async def test_acct_user_id_filtering(client, app, endpoint):
+    """Test that accounting routes correctly filter by user_ids
+
+    Rationale:
+    - Populate DB with 10 users with each one session with one job
+    - So, for any route, len(data) = number of user_id selected
+    """
+
+    N_USERS = 10
+
+    user_ids, _, _ = await acct_populate_db(
+        app,
+        N_USERS,
+    )
+
+    # No filter
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(endpoint + "?start_datetime=1999-01-01&limit=10")
+    assert response.status_code == 200
+    assert len(response.json()["data"]) == N_USERS
+
+    # Filter with all user_ids
+    with mock_munge_auth(app, uid=0):
+        request = endpoint + "?start_datetime=1999-01-01&limit=10"
+        for user_id in user_ids:
+            request += "&user_ids=" + user_id
+        response = await client.get(request)
+    assert response.status_code == 200
+    assert len(response.json()["data"]) == N_USERS
+
+    # Filter with 3 existing user_ids
+    selected_ids = user_ids[:3]
+    with mock_munge_auth(app, uid=0):
+        request = endpoint + "?start_datetime=1999-01-01&limit=10"
+        for user_id in selected_ids:
+            request += "&user_ids=" + user_id
+        response = await client.get(request)
+    assert response.status_code == 200
+    assert len(response.json()["data"]) == 3
+    for row in response.json()["data"]:
+        assert row["user_id"] in selected_ids
+
+    # Filter with a non-existent user_id
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            endpoint
+            + "?start_datetime=1999-01-01&limit=10"
+            + "&user_ids=9999999999999999999999999"
+        )
+    assert response.status_code == 200
+    assert len(response.json()["data"]) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ACCT_ENDPOINTS)
+async def test_acct_datetime_filter(client, app, endpoint):
+    """Assert that the accounting data query correctly filters sessions according to start/end datetime."""
 
     N_USERS = 10
     FIRST_SESSION_START = datetime(2026, 1, 1, 0, 0, 0)
@@ -95,12 +185,13 @@ async def test_acct_datetime_filter(client, app):
         n_users=N_USERS,
         session_duration=SESSION_DURATION,
         user_time_offset=USER_TIME_OFFSET,
+        job_statuses=("DONE",),
     )
 
     # Test default get all
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            ACCT_ENDPOINT + "?start_datetime=" + FIRST_SESSION_START.isoformat()
+            endpoint + "?start_datetime=" + FIRST_SESSION_START.isoformat()
         )
     assert response.status_code == 200
     assert len(response.json()["data"]) == N_USERS
@@ -127,7 +218,7 @@ async def test_acct_datetime_filter(client, app):
     assert second_session.revoked_at is not None
     with mock_munge_auth(app, uid=0):
         response_before = await client.get(
-            ACCT_ENDPOINT
+            endpoint
             + "?start_datetime="
             + FIRST_SESSION_START.isoformat()
             + "&end_datetime="
@@ -135,7 +226,7 @@ async def test_acct_datetime_filter(client, app):
             + "&limit=100"
         )
         response_after = await client.get(
-            ACCT_ENDPOINT
+            endpoint
             + "?start_datetime="
             + second_session.revoked_at.isoformat()
             + "&limit=100"
@@ -147,33 +238,11 @@ async def test_acct_datetime_filter(client, app):
     assert len(response_after.json()["data"]) == 9
 
 
-# def test_acct_request_normalizes_datetimes_to_naive_utc():
-#     """The `start_datetime`/`end_datetime` validator must produce naive UTC
-#     values regardless of the offset supplied by the caller, since not every
-#     supported DB backend preserves timezone info on stored columns."""
-
-#     naive_utc = datetime(2026, 1, 1, 12, 0, 0)
-#     aware_non_utc = naive_utc.replace(tzinfo=timezone(timedelta(hours=2))) + timedelta(
-#         hours=2
-#     )
-
-#     req = AcctRequest(start_datetime=aware_non_utc, end_datetime=aware_non_utc)
-#     assert req.start_datetime == naive_utc
-#     assert req.start_datetime.tzinfo is None
-#     assert req.end_datetime == naive_utc
-#     assert req.end_datetime.tzinfo is None
-
-#     # Naive input is assumed to already be UTC and passed through unchanged.
-#     req_naive = AcctRequest(start_datetime=naive_utc)
-#     assert req_naive.start_datetime == naive_utc
-#     assert req_naive.start_datetime.tzinfo is None
-
-#     # end_datetime is optional; None must pass through untouched.
-#     assert req_naive.end_datetime is None
-
-
 @pytest.mark.asyncio
-async def test_acct_datetime_filter_accepts_timezone_aware_query_params(client, app):
+@pytest.mark.parametrize("endpoint", ACCT_ENDPOINTS)
+async def test_acct_datetime_filter_accepts_timezone_aware_query_params(
+    client, app, endpoint
+):
     """Assert that a start_datetime with a non-UTC offset selects the same
     rows as its naive-UTC equivalent, i.e. the request-level normalization
     is actually applied to query params, not just direct model usage."""
@@ -201,13 +270,13 @@ async def test_acct_datetime_filter_accepts_timezone_aware_query_params(client, 
 
     with mock_munge_auth(app, uid=0):
         response_naive = await client.get(
-            ACCT_ENDPOINT
+            endpoint
             + "?start_datetime="
             + second_session.revoked_at.isoformat()
             + "&limit=100"
         )
         response_aware = await client.get(
-            ACCT_ENDPOINT
+            endpoint
             + "?start_datetime="
             # `+` is form-encoding shorthand for a space in query strings, so
             # a raw `+HH:MM` offset must be percent-encoded, same as any real
@@ -220,6 +289,11 @@ async def test_acct_datetime_filter_accepts_timezone_aware_query_params(client, 
     assert response_naive.json()["data"] == response_aware.json()["data"]
 
 
+###############################################################################
+############################ /accounting ROUTE TESTS ##########################
+###############################################################################
+
+
 @pytest.mark.asyncio
 async def test_acct_reported_durations(client, app):
     """Assert that reported session and job durations are the real elapsed seconds.
@@ -228,14 +302,21 @@ async def test_acct_reported_durations(client, app):
     meaning on PostgreSQL. This pins the value on every supported backend.
     """
     N_USERS = 3
-    SESSION_DURATION = timedelta(hours=1)
-    EXPECTED_SECONDS = int(SESSION_DURATION.total_seconds())
+    SESSION_DURATION = timedelta(seconds=60)
 
+    JOB_WAIT = timedelta(seconds=15)
+    JOB_EXECUTION = timedelta(seconds=45)
     await acct_populate_db(
         app,
         n_users=N_USERS,
         session_duration=SESSION_DURATION,
+        job_wait_time=JOB_WAIT,
+        job_execution_time=JOB_EXECUTION,
     )
+
+    SESSION_DURATION = int(SESSION_DURATION.total_seconds())
+    JOB_WAIT_TIME = int(JOB_WAIT.total_seconds())
+    JOB_EXECUTION_TIME = int(JOB_EXECUTION.total_seconds())
 
     with mock_munge_auth(app, uid=0):
         response = await client.get(
@@ -249,17 +330,18 @@ async def test_acct_reported_durations(client, app):
     for user_data in data:
         # One session of SESSION_DURATION per user.
         assert user_data["sessions"]["count"] == 1
-        assert user_data["sessions"]["total_duration"] == EXPECTED_SECONDS
+        assert user_data["sessions"]["total_duration"] == SESSION_DURATION
 
         # One job, spanning the whole session.
         assert user_data["jobs"]["count"] == 1
         assert len(user_data["jobs"]["stats"]) == 1
-        assert user_data["jobs"]["stats"][0]["execution_time"] == EXPECTED_SECONDS
-        assert user_data["jobs"]["stats"][0]["wait_time"] == 0
+        assert user_data["jobs"]["stats"][0]["execution_time"] == JOB_EXECUTION_TIME
+        assert user_data["jobs"]["stats"][0]["wait_time"] == JOB_WAIT_TIME
 
 
 @pytest.mark.asyncio
-async def test_acct_jobs_are_aligned_with_paginated_users(client, app):
+@pytest.mark.parametrize("endpoint", (ACCT_ENDPOINT,))
+async def test_acct_jobs_are_aligned_with_paginated_users(client, app, endpoint):
     """Assert that job stats belong to the users on the returned page.
 
     The sessions aggregation groups by user, the jobs aggregation groups by
@@ -280,7 +362,7 @@ async def test_acct_jobs_are_aligned_with_paginated_users(client, app):
 
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            ACCT_ENDPOINT
+            endpoint
             + f"?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}"
             + f"&offset={PAGINATION_OFFSET}"
         )
@@ -305,112 +387,9 @@ async def test_acct_jobs_are_aligned_with_paginated_users(client, app):
             assert stat["count"] == 1
 
 
-@pytest.mark.asyncio
-async def test_acct_user_filtering(client, app):
-    """Assert that accounting data can be filtered by user"""
-
-    N_USERS = 10
-    JOB_STATUSES = ("DONE", "ERROR", "CANCELED")
-
-    user_uids, _, _ = await acct_populate_db(
-        app,
-        n_users=N_USERS,
-        job_statuses=JOB_STATUSES,
-    )
-
-    # Filter with a single user
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_ENDPOINT
-            + "?start_datetime=2020-01-01T00:00:00"
-            + f"&user_ids={user_uids[0]}"
-        )
-    assert response.status_code == 200
-
-    data = response.json()["data"]
-    assert len(data) == 1
-    assert data[0]["user_id"] == user_uids[0]
-
-    # Filter with several users
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_ENDPOINT
-            + "?start_datetime=2020-01-01T00:00:00"
-            + f"&user_ids={user_uids[0]}"
-            + f"&user_ids={user_uids[1]}"
-            + f"&user_ids={user_uids[2]}"
-            + f"&user_ids={user_uids[3]}"
-        )
-    assert response.status_code == 200
-
-    data = response.json()["data"]
-    assert len(data) == 4
-    assert data[0]["user_id"] == user_uids[0]
-    assert data[1]["user_id"] == user_uids[1]
-    assert data[2]["user_id"] == user_uids[2]
-    assert data[3]["user_id"] == user_uids[3]
-
-    # Filter with non-existing user
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_ENDPOINT + "?start_datetime=2020-01-01T00:00:00" + "&user_ids=9999999"
-        )
-    assert response.status_code == 200
-
-    data = response.json()["data"]
-    assert len(data) == 0
-
-
-@pytest.mark.asyncio
-async def test_acct_jobs_user_filtering(client, app):
-    """Assert that /accounting/jobs filters by user and reports the right count."""
-    N_USERS = 3
-    JOB_STATUSES = ("DONE", "ERROR")
-
-    user_uids, _, _ = await acct_populate_db(
-        app,
-        n_users=N_USERS,
-        job_statuses=JOB_STATUSES,
-    )
-
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_JOBS_ENDPOINT
-            + "?start_datetime=2020-01-01T00:00:00"
-            + f"&user_ids={user_uids[0]}"
-        )
-    assert response.status_code == 200
-
-    body = response.json()
-    assert body["pagination"]["total"] == len(JOB_STATUSES)
-    assert len(body["data"]) == len(JOB_STATUSES)
-    assert all(job["user_id"] == user_uids[0] for job in body["data"])
-
-
-@pytest.mark.asyncio
-async def test_acct_jobs_session_id_filtering(client, app):
-    """Assert that /accounting/jobs can be filtered by session_id."""
-    N_USERS = 2
-    JOB_STATUSES = ("DONE", "ERROR")
-
-    _, _, sessions = await acct_populate_db(
-        app,
-        n_users=N_USERS,
-        job_statuses=JOB_STATUSES,
-    )
-
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_JOBS_ENDPOINT
-            + "?start_datetime=2020-01-01T00:00:00"
-            + f"&session_id={sessions[0].id}"
-        )
-    assert response.status_code == 200
-
-    body = response.json()
-    assert body["pagination"]["total"] == len(JOB_STATUSES)
-    assert len(body["data"]) == len(JOB_STATUSES)
-    assert all(job["session_id"] == str(sessions[0].id) for job in body["data"])
+###############################################################################
+####################### /accounting/sessions ROUTE TESTS ######################
+###############################################################################
 
 
 @pytest.mark.asyncio
@@ -446,22 +425,58 @@ async def test_acct_sessions_nominal(client, app):
         assert session_data["jobs_count"] == len(JOB_STATUSES)
 
 
-@pytest.mark.asyncio
-async def test_acct_jobs_nominal(client, app):
-    """Assert that /accounting/jobs lists one row per job with its own
-    status and durations."""
-    N_USERS = 2
-    SESSION_DURATION = timedelta(minutes=20)
+###############################################################################
+######################### /accounting/jobs ROUTE TESTS ########################
+###############################################################################
 
-    user_uids, jobs, _ = await acct_populate_db(
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", (ACCT_JOBS_ENDPOINT,))
+async def test_acct_jobs_session_id_filtering(client, app, endpoint):
+    """Assert that /accounting/jobs can be filtered by session_id."""
+    N_USERS = 2
+    JOB_STATUSES = ("DONE", "ERROR")
+
+    _, _, sessions = await acct_populate_db(
         app,
         n_users=N_USERS,
-        session_duration=SESSION_DURATION,
+        job_statuses=JOB_STATUSES,
     )
 
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            ACCT_JOBS_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
+            endpoint
+            + "?start_datetime=2020-01-01T00:00:00"
+            + f"&session_id={sessions[0].id}"
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == len(JOB_STATUSES)
+    assert len(body["data"]) == len(JOB_STATUSES)
+    assert all(job["session_id"] == str(sessions[0].id) for job in body["data"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", (ACCT_JOBS_ENDPOINT,))
+async def test_acct_jobs_nominal(client, app, endpoint):
+    """Assert that /accounting/jobs lists one row per job with its own
+    status and durations."""
+    N_USERS = 2
+
+    JOB_WAIT = timedelta(seconds=30)
+    JOB_EXECUTION = timedelta(seconds=60)
+
+    EXPECTED_WAIT_TIME = int(JOB_WAIT.total_seconds())
+    EXPECTED_EXECUTION_TIME = int(JOB_EXECUTION.total_seconds())
+
+    user_uids, jobs, _ = await acct_populate_db(
+        app, n_users=N_USERS, job_wait_time=JOB_WAIT, job_execution_time=JOB_EXECUTION
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            endpoint + "?start_datetime=2020-01-01T00:00:00&limit=100"
         )
     assert response.status_code == 200
 
@@ -469,10 +484,9 @@ async def test_acct_jobs_nominal(client, app):
     assert body["pagination"]["total"] == N_USERS
     assert len(body["data"]) == N_USERS
 
-    expected_execution_time = int(SESSION_DURATION.total_seconds())
     for i, job_data in enumerate(body["data"]):
         assert job_data["id"] == jobs[i].id
         assert job_data["user_id"] == user_uids[i]
         assert job_data["status"] == "DONE"
-        assert job_data["execution_time"] == expected_execution_time
-        assert job_data["wait_time"] == 0
+        assert job_data["execution_time"] == EXPECTED_EXECUTION_TIME
+        assert job_data["wait_time"] == EXPECTED_WAIT_TIME

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -209,7 +209,8 @@ async def test_acct_reported_durations(client, app, serialized_sequence):
         # One job, spanning the whole session.
         assert user_data["jobs"]["count"] == 1
         assert len(user_data["jobs"]["stats"]) == 1
-        assert user_data["jobs"]["stats"][0]["total_duration"] == EXPECTED_SECONDS
+        assert user_data["jobs"]["stats"][0]["execution_time"] == EXPECTED_SECONDS
+        assert user_data["jobs"]["stats"][0]["wait_time"] == 0
 
 
 @pytest.mark.asyncio
@@ -317,4 +318,3 @@ async def test_acct_user_filtering(client, app, serialized_sequence):
 
     data = response.json()["data"]
     assert len(data) == 0
-

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -3,8 +3,7 @@ from datetime import datetime, timedelta
 import pytest
 from httpx import AsyncClient
 
-from tests.api.conftest import mock_munge_auth
-from warden.lib.models import Job, Session
+from tests.api.conftest import acct_populate_db, mock_munge_auth
 
 ACCT_ENDPOINT = "/acct"
 
@@ -29,48 +28,11 @@ async def test_acct_required_start(client: AsyncClient, app):
 
 
 @pytest.mark.asyncio
-async def test_acct_nominal_pagination(client, app, serialized_sequence):
+async def test_acct_nominal_pagination_filter(client, app, serialized_sequence):
     """Assert that the accounting data query returns the right number of rows."""
-    START_DATETIME = datetime(2026, 1, 1, 0, 0, 0)
-    END_DATETIME = datetime(2026, 1, 1, 1, 0, 0)
     N_USERS = 10
-    user_uids = [str(i) for i in range(1000, 1000 + N_USERS)]
 
-    # Create at least one session and job per user
-    sessions = []
-    jobs = []
-    for i, uid in enumerate(user_uids):
-        start_session = START_DATETIME + timedelta(hours=i)
-        end_session = END_DATETIME + timedelta(hours=i)
-
-        sessions.append(
-            Session(
-                created_at=start_session,
-                revoked_at=end_session,
-                user_id=uid,
-                slurm_job_id=str(i),
-            )
-        )
-        jobs.append(
-            Job(
-                status="DONE",
-                logs="",
-                shots=100,
-                sequence=serialized_sequence,
-                created_at=start_session,
-                scheduled_at=start_session,
-                started_at=start_session,
-                ended_at=end_session,
-                # Relationship
-                session=sessions[-1],
-            )
-        )
-
-    async_session_factory = app.state.db_session_factory
-    async with async_session_factory() as db_session:
-        db_session.add_all(sessions)
-        db_session.add_all(jobs)
-        await db_session.commit()
+    user_uids, _, _ = await acct_populate_db(app, serialized_sequence, N_USERS)
 
     # Test default
     with mock_munge_auth(app, uid=0):
@@ -128,3 +90,68 @@ async def test_acct_nominal_pagination(client, app, serialized_sequence):
     assert response.json()["pagination"]["end"] == N_USERS
     assert len(response.json()["data"]) == 2
     assert response.json()["data"][0]["user_id"] == user_uids[N_USERS - 2]
+
+
+@pytest.mark.asyncio
+async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
+    """Assert that the accounting data query correctly filters according to start/end datetime."""
+
+    N_USERS = 10
+    FIRST_SESSION_START = datetime(2026, 1, 1, 0, 0, 0)
+
+    SESSION_DURATION = timedelta(minutes=45)
+    USER_TIME_OFFSET = timedelta(hours=1)
+
+    user_ids, _, sessions = await acct_populate_db(
+        app,
+        serialized_sequence,
+        first_session_start=FIRST_SESSION_START,
+        n_users=N_USERS,
+        session_duration=SESSION_DURATION,
+        user_time_offset=USER_TIME_OFFSET,
+    )
+
+    # Test default get all
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT + "?start_datetime=" + FIRST_SESSION_START.isoformat()
+        )
+    assert response.status_code == 200
+    assert len(response.json()["data"]) == N_USERS
+    assert response.json()["data"][0]["user_id"] == user_ids[0]
+
+    # Test filtering only first user session
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT
+            + "?start_datetime="
+            + FIRST_SESSION_START.isoformat()
+            + "&end_datetime="
+            + (sessions[0].revoked_at + timedelta(seconds=1)).isoformat()
+        )
+    assert response.status_code == 200
+    assert len(response.json()["data"]) == 1
+    assert response.json()["data"][0]["user_id"] == user_ids[0]
+
+    # Test time filtering is total partition of data
+    # We split the filtering exactly at the revocation time of the 2nd user's session
+    with mock_munge_auth(app, uid=0):
+        response_before = await client.get(
+            ACCT_ENDPOINT
+            + "?start_datetime="
+            + FIRST_SESSION_START.isoformat()
+            + "&end_datetime="
+            + sessions[1].revoked_at.isoformat()
+            + "&limit=100"
+        )
+        response_after = await client.get(
+            ACCT_ENDPOINT
+            + "?start_datetime="
+            + sessions[1].revoked_at.isoformat()
+            + "&limit=100"
+        )
+    assert response_after.status_code == 200
+    assert response_before.status_code == 200
+
+    assert len(response_before.json()["data"]) == 1
+    assert len(response_after.json()["data"]) == 9

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -393,7 +393,38 @@ async def test_acct_jobs_are_aligned_with_paginated_users(client, app, endpoint)
 
 
 @pytest.mark.asyncio
-async def test_acct_sessions_nominal(client, app):
+@pytest.mark.parametrize("endpoint", (ACCT_SESSIONS_ENDPOINT,))
+@pytest.mark.parametrize(
+    "query,expected", (("&slurm_job_id=9999", 0), ("&slurm_job_id=1", 1))
+)
+async def test_acct_session_slurm_job_id_filtering(
+    client, app, endpoint, query, expected
+):
+    """Assert that /accounting/sessions can be filtered by slurm_job_id."""
+    N_USERS = 10
+    JOB_STATUSES = ("DONE", "ERROR")
+
+    await acct_populate_db(
+        app,
+        n_users=N_USERS,
+        job_statuses=JOB_STATUSES,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            endpoint + "?start_datetime=2020-01-01T00:00:00" + query
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == expected
+    assert len(body["data"]) == expected
+    # TODO: check content of data ?
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", (ACCT_SESSIONS_ENDPOINT,))
+async def test_acct_sessions_nominal(client, app, endpoint):
     """Assert that /accounting/sessions lists one row per session with its
     own duration and job count."""
     N_USERS = 4
@@ -409,7 +440,7 @@ async def test_acct_sessions_nominal(client, app):
 
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            ACCT_SESSIONS_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
+            endpoint + "?start_datetime=2020-01-01T00:00:00&limit=100"
         )
     assert response.status_code == 200
 
@@ -455,6 +486,34 @@ async def test_acct_jobs_session_id_filtering(client, app, endpoint):
     assert body["pagination"]["total"] == len(JOB_STATUSES)
     assert len(body["data"]) == len(JOB_STATUSES)
     assert all(job["session_id"] == str(sessions[0].id) for job in body["data"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", (ACCT_JOBS_ENDPOINT,))
+@pytest.mark.parametrize(
+    "query,expected", (("", 30), ("&status=NOTASTATUS", 0), ("&status=DONE", 10))
+)
+async def test_acct_jobs_status_filtering(client, app, endpoint, query, expected):
+    """Assert that /accounting/jobs can be filtered by Job status."""
+    N_USERS = 10
+    JOB_STATUSES = ("DONE", "CANCELED", "ERROR")
+
+    await acct_populate_db(
+        app,
+        n_users=N_USERS,
+        job_statuses=JOB_STATUSES,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            endpoint + "?start_datetime=2020-01-01T00:00:00" + query
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == expected
+    assert len(body["data"]) == expected
+    # TODO: check content of data ?
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -295,7 +295,98 @@ async def test_acct_datetime_filter_accepts_timezone_aware_query_params(
 
 
 @pytest.mark.asyncio
-async def test_acct_reported_durations(client, app):
+@pytest.mark.parametrize("endpoint", (ACCT_ENDPOINT,))
+async def test_acct_nominal(client, app, endpoint):
+    """Assert that /accounting lists one row per user with its session and
+    job summaries (counts and durations) correctly aggregated."""
+    N_USERS = 3
+    JOB_STATUSES = ("DONE", "ERROR")
+    SESSION_DURATION = timedelta(minutes=30)
+    JOB_WAIT = timedelta(seconds=15)
+    JOB_EXECUTION = timedelta(seconds=45)
+
+    user_uids, _, _ = await acct_populate_db(
+        app,
+        n_users=N_USERS,
+        session_duration=SESSION_DURATION,
+        job_statuses=JOB_STATUSES,
+        job_wait_time=JOB_WAIT,
+        job_execution_time=JOB_EXECUTION,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            endpoint + "?start_datetime=2020-01-01T00:00:00&limit=100"
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == N_USERS
+    assert len(body["data"]) == N_USERS
+
+    expected_session_duration = int(SESSION_DURATION.total_seconds())
+    expected_wait_time = int(JOB_WAIT.total_seconds())
+    expected_execution_time = int(JOB_EXECUTION.total_seconds())
+    # One job per status, so per-user totals are the per-job time times the
+    # number of statuses.
+    expected_jobs_execution_time = expected_execution_time * len(JOB_STATUSES)
+    expected_jobs_wait_time = expected_wait_time * len(JOB_STATUSES)
+
+    for i, user_data in enumerate(body["data"]):
+        assert user_data["user_id"] == user_uids[i]
+        assert user_data["sessions"]["count"] == 1
+        assert user_data["sessions"]["total_duration"] == expected_session_duration
+        assert user_data["jobs"]["count"] == len(JOB_STATUSES)
+        assert user_data["jobs"]["execution_time"] == expected_jobs_execution_time
+        assert user_data["jobs"]["wait_time"] == expected_jobs_wait_time
+        assert {stat["status"] for stat in user_data["jobs"]["stats"]} == set(
+            JOB_STATUSES
+        )
+        for stat in user_data["jobs"]["stats"]:
+            assert stat["count"] == 1
+            assert stat["execution_time"] == expected_execution_time
+            assert stat["wait_time"] == expected_wait_time
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", (ACCT_ENDPOINT,))
+async def test_acct_session_without_jobs(client, app, endpoint):
+    """Assert that a session with no job is still reported, with an empty
+    job summary rather than a missing/erroring row."""
+    N_USERS = 2
+    SESSION_DURATION = timedelta(minutes=30)
+
+    user_uids, _, _ = await acct_populate_db(
+        app,
+        n_users=N_USERS,
+        session_duration=SESSION_DURATION,
+        job_statuses=(),
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            endpoint + "?start_datetime=2020-01-01T00:00:00&limit=100"
+        )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["pagination"]["total"] == N_USERS
+    assert len(body["data"]) == N_USERS
+
+    expected_session_duration = int(SESSION_DURATION.total_seconds())
+    for i, user_data in enumerate(body["data"]):
+        assert user_data["user_id"] == user_uids[i]
+        assert user_data["sessions"]["count"] == 1
+        assert user_data["sessions"]["total_duration"] == expected_session_duration
+        assert user_data["jobs"]["count"] == 0
+        assert user_data["jobs"]["execution_time"] == 0
+        assert user_data["jobs"]["wait_time"] == 0
+        assert user_data["jobs"]["stats"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", (ACCT_ENDPOINT,))
+async def test_acct_reported_durations(client, app, endpoint):
     """Assert that reported session and job durations are the real elapsed seconds.
 
     The aggregation uses ``extract('epoch', ...)``, which only has the intended
@@ -320,7 +411,7 @@ async def test_acct_reported_durations(client, app):
 
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            ACCT_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
+            endpoint + "?start_datetime=2020-01-01T00:00:00&limit=100"
         )
     assert response.status_code == 200
 
@@ -452,6 +543,7 @@ async def test_acct_sessions_nominal(client, app, endpoint):
     for i, session_data in enumerate(body["data"]):
         assert session_data["id"] == str(sessions[i].id)
         assert session_data["user_id"] == user_uids[i]
+        assert session_data["slurm_job_id"] == sessions[i].slurm_job_id
         assert session_data["total_duration"] == expected_duration
         assert session_data["jobs_count"] == len(JOB_STATUSES)
 
@@ -530,7 +622,11 @@ async def test_acct_jobs_nominal(client, app, endpoint):
     EXPECTED_EXECUTION_TIME = int(JOB_EXECUTION.total_seconds())
 
     user_uids, jobs, _ = await acct_populate_db(
-        app, n_users=N_USERS, job_wait_time=JOB_WAIT, job_execution_time=JOB_EXECUTION
+        app,
+        n_users=N_USERS,
+        job_wait_time=JOB_WAIT,
+        job_execution_time=JOB_EXECUTION,
+        job_statuses=("DONE",),
     )
 
     with mock_munge_auth(app, uid=0):
@@ -546,6 +642,7 @@ async def test_acct_jobs_nominal(client, app, endpoint):
     for i, job_data in enumerate(body["data"]):
         assert job_data["id"] == jobs[i].id
         assert job_data["user_id"] == user_uids[i]
+        assert job_data["session_id"] == str(jobs[i].session_id)
         assert job_data["status"] == "DONE"
         assert job_data["execution_time"] == EXPECTED_EXECUTION_TIME
         assert job_data["wait_time"] == EXPECTED_WAIT_TIME

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 
 from tests.api.conftest import acct_populate_db, mock_munge_auth
 
-ACCT_ENDPOINT = "/acct"
+ACCT_ENDPOINT = "/accounting"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -121,13 +121,15 @@ async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
     assert response.json()["data"][0]["user_id"] == user_ids[0]
 
     # Test filtering only first user session
+    first_session = sessions[0]
+    assert first_session.revoked_at is not None
     with mock_munge_auth(app, uid=0):
         response = await client.get(
             ACCT_ENDPOINT
             + "?start_datetime="
             + FIRST_SESSION_START.isoformat()
             + "&end_datetime="
-            + (sessions[0].revoked_at + timedelta(seconds=1)).isoformat()
+            + (first_session.revoked_at + timedelta(seconds=1)).isoformat()
         )
     assert response.status_code == 200
     assert len(response.json()["data"]) == 1
@@ -135,19 +137,21 @@ async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
 
     # Test time filtering is total partition of data
     # We split the filtering exactly at the revocation time of the 2nd user's session
+    second_session = sessions[1]
+    assert second_session.revoked_at is not None
     with mock_munge_auth(app, uid=0):
         response_before = await client.get(
             ACCT_ENDPOINT
             + "?start_datetime="
             + FIRST_SESSION_START.isoformat()
             + "&end_datetime="
-            + sessions[1].revoked_at.isoformat()
+            + second_session.revoked_at.isoformat()
             + "&limit=100"
         )
         response_after = await client.get(
             ACCT_ENDPOINT
             + "?start_datetime="
-            + sessions[1].revoked_at.isoformat()
+            + second_session.revoked_at.isoformat()
             + "&limit=100"
         )
     assert response_after.status_code == 200

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -6,21 +6,25 @@ from httpx import AsyncClient
 from tests.api.conftest import mock_munge_auth
 from warden.lib.models import Job, Session
 
+ACCT_ENDPOINT = "/acct"
+
 
 @pytest.mark.asyncio
 async def test_acct_required_start(client: AsyncClient, app):
     """Assert that 'start_datetime' is required in the accounting data query."""
 
     with mock_munge_auth(app, uid=0):
-        response = await client.get("/acct")
+        response = await client.get(ACCT_ENDPOINT)
     assert response.status_code == 422
 
     with mock_munge_auth(app, uid=0):
-        response = await client.get("/acct?end_datetime=2022-01-01T00:00:00")
+        response = await client.get(ACCT_ENDPOINT + "?end_datetime=2022-01-01T00:00:00")
     assert response.status_code == 422
 
     with mock_munge_auth(app, uid=0):
-        response = await client.get("/acct?start_datetime=2022-01-01T00:00:00")
+        response = await client.get(
+            ACCT_ENDPOINT + "?start_datetime=2022-01-01T00:00:00"
+        )
     assert response.status_code == 200
 
 
@@ -30,8 +34,6 @@ async def test_acct_nominal_pagination(client, app, serialized_sequence):
     START_DATETIME = datetime(2026, 1, 1, 0, 0, 0)
     END_DATETIME = datetime(2026, 1, 1, 1, 0, 0)
     N_USERS = 10
-    PAGINATION_LIMIT = 5
-    PAGINATION_OFFSET = 4
     user_uids = [str(i) for i in range(1000, 1000 + N_USERS)]
 
     # Create at least one session and job per user
@@ -73,28 +75,56 @@ async def test_acct_nominal_pagination(client, app, serialized_sequence):
     # Test default
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            "/acct?start_datetime=2020-01-01T00:00:00&limit=100"
+            ACCT_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
         )
     assert response.status_code == 200
     assert response.json()["pagination"]["total"] == N_USERS
+    assert response.json()["pagination"]["start"] == 0
+    assert response.json()["pagination"]["end"] == N_USERS
     assert len(response.json()["data"]) == N_USERS
     assert response.json()["data"][0]["user_id"] == user_uids[0]
 
-    # Test pagination
+    # Test pagination limit
+    PAGINATION_LIMIT = 5
+    assert PAGINATION_LIMIT < N_USERS
+
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            f"/acct?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}"
+            ACCT_ENDPOINT
+            + f"?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}"
         )
     assert response.status_code == 200
     assert response.json()["pagination"]["total"] == N_USERS
+    assert response.json()["pagination"]["start"] == 0
+    assert response.json()["pagination"]["end"] == PAGINATION_LIMIT
     assert len(response.json()["data"]) == PAGINATION_LIMIT
+    assert response.json()["data"][0]["user_id"] == user_uids[0]
 
     # Test offset
+    PAGINATION_LIMIT = 5
+    PAGINATION_OFFSET = 4
+    assert PAGINATION_LIMIT + PAGINATION_OFFSET < N_USERS
+
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            f"/acct?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}&offset={PAGINATION_OFFSET}"
+            ACCT_ENDPOINT
+            + f"?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}&offset={PAGINATION_OFFSET}"
         )
     assert response.status_code == 200
     assert response.json()["pagination"]["total"] == N_USERS
+    assert response.json()["pagination"]["start"] == PAGINATION_OFFSET
+    assert response.json()["pagination"]["end"] == PAGINATION_LIMIT + PAGINATION_OFFSET
     assert len(response.json()["data"]) == PAGINATION_LIMIT
     assert response.json()["data"][0]["user_id"] == user_uids[PAGINATION_OFFSET]
+
+    # Test offset end of data length
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT + f"?start_datetime=2020-01-01T00:00:00&offset={N_USERS - 2}"
+        )
+    assert response.status_code == 200
+    assert response.json()["pagination"]["total"] == N_USERS
+    assert response.json()["pagination"]["start"] == N_USERS - 2
+    assert response.json()["pagination"]["end"] == N_USERS
+    assert len(response.json()["data"]) == 2
+    assert response.json()["data"][0]["user_id"] == user_uids[N_USERS - 2]

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -1,0 +1,100 @@
+from datetime import datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from tests.api.conftest import mock_munge_auth
+from warden.lib.models import Job, Session
+
+
+@pytest.mark.asyncio
+async def test_acct_required_start(client: AsyncClient, app):
+    """Assert that 'start_datetime' is required in the accounting data query."""
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get("/acct")
+    assert response.status_code == 422
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get("/acct?end_datetime=2022-01-01T00:00:00")
+    assert response.status_code == 422
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get("/acct?start_datetime=2022-01-01T00:00:00")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_acct_nominal_pagination(client, app, serialized_sequence):
+    """Assert that the accounting data query returns the right number of rows."""
+    START_DATETIME = datetime(2026, 1, 1, 0, 0, 0)
+    END_DATETIME = datetime(2026, 1, 1, 1, 0, 0)
+    N_USERS = 10
+    PAGINATION_LIMIT = 5
+    PAGINATION_OFFSET = 4
+    user_uids = [str(i) for i in range(1000, 1000 + N_USERS)]
+
+    # Create at least one session and job per user
+    sessions = []
+    jobs = []
+    for i, uid in enumerate(user_uids):
+        start_session = START_DATETIME + timedelta(hours=i)
+        end_session = END_DATETIME + timedelta(hours=i)
+
+        sessions.append(
+            Session(
+                created_at=start_session,
+                revoked_at=end_session,
+                user_id=uid,
+                slurm_job_id=str(i),
+            )
+        )
+        jobs.append(
+            Job(
+                status="DONE",
+                logs="",
+                shots=100,
+                sequence=serialized_sequence,
+                created_at=start_session,
+                scheduled_at=start_session,
+                started_at=start_session,
+                ended_at=end_session,
+                # Relationship
+                session=sessions[-1],
+            )
+        )
+
+    async_session_factory = app.state.db_session_factory
+    async with async_session_factory() as db_session:
+        db_session.add_all(sessions)
+        db_session.add_all(jobs)
+        await db_session.commit()
+
+    # Test default
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            "/acct?start_datetime=2020-01-01T00:00:00&limit=100"
+        )
+    assert response.status_code == 200
+    assert response.json()["pagination"]["total"] == N_USERS
+    assert len(response.json()["data"]) == N_USERS
+    assert response.json()["data"][0]["user_id"] == user_uids[0]
+
+    # Test pagination
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            f"/acct?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}"
+        )
+    assert response.status_code == 200
+    assert response.json()["pagination"]["total"] == N_USERS
+    assert len(response.json()["data"]) == PAGINATION_LIMIT
+
+    # Test offset
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            f"/acct?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}&offset={PAGINATION_OFFSET}"
+        )
+    assert response.status_code == 200
+    assert response.json()["pagination"]["total"] == N_USERS
+    assert len(response.json()["data"]) == PAGINATION_LIMIT
+    assert response.json()["data"][0]["user_id"] == user_uids[PAGINATION_OFFSET]

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -260,3 +260,61 @@ async def test_acct_jobs_are_aligned_with_paginated_users(
         )
         for stat in user_data["jobs"]["stats"]:
             assert stat["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_acct_user_filtering(client, app, serialized_sequence):
+    """Assert that accounting data can be filtered by user"""
+
+    N_USERS = 10
+    JOB_STATUSES = ("DONE", "ERROR", "CANCELED")
+
+    user_uids, _, _ = await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        job_statuses=JOB_STATUSES,
+    )
+
+    # Filter with a single user
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT
+            + "?start_datetime=2020-01-01T00:00:00"
+            + f"&user_ids={user_uids[0]}"
+        )
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["user_id"] == user_uids[0]
+
+    # Filter with several users
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT
+            + "?start_datetime=2020-01-01T00:00:00"
+            + f"&user_ids={user_uids[0]}"
+            + f"&user_ids={user_uids[1]}"
+            + f"&user_ids={user_uids[2]}"
+            + f"&user_ids={user_uids[3]}"
+        )
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert len(data) == 4
+    assert data[0]["user_id"] == user_uids[0]
+    assert data[1]["user_id"] == user_uids[1]
+    assert data[2]["user_id"] == user_uids[2]
+    assert data[3]["user_id"] == user_uids[3]
+
+    # Filter with non-existing user
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT + "?start_datetime=2020-01-01T00:00:00" + "&user_ids=9999999"
+        )
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert len(data) == 0
+

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -91,6 +91,19 @@ async def test_acct_nominal_pagination_filter(client, app, serialized_sequence):
     assert len(response.json()["data"]) == 2
     assert response.json()["data"][0]["user_id"] == user_uids[N_USERS - 2]
 
+    # Test offset past the end: the page is empty, and start/end are clamped to
+    # total so the response stays consistent (end - start == 0 items, never
+    # pointing beyond the data).
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT + f"?start_datetime=2020-01-01T00:00:00&offset={N_USERS + 10}"
+        )
+    assert response.status_code == 200
+    assert response.json()["pagination"]["total"] == N_USERS
+    assert response.json()["pagination"]["start"] == N_USERS
+    assert response.json()["pagination"]["end"] == N_USERS
+    assert len(response.json()["data"]) == 0
+
 
 @pytest.mark.asyncio
 async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
@@ -159,3 +172,91 @@ async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
 
     assert len(response_before.json()["data"]) == 1
     assert len(response_after.json()["data"]) == 9
+
+
+@pytest.mark.asyncio
+async def test_acct_reported_durations(client, app, serialized_sequence):
+    """Assert that reported session and job durations are the real elapsed seconds.
+
+    The aggregation uses ``extract('epoch', ...)``, which only has the intended
+    meaning on PostgreSQL. This pins the value on every supported backend.
+    """
+    N_USERS = 3
+    SESSION_DURATION = timedelta(hours=1)
+    EXPECTED_SECONDS = int(SESSION_DURATION.total_seconds())
+
+    await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        session_duration=SESSION_DURATION,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
+        )
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert len(data) == N_USERS
+
+    for user_data in data:
+        # One session of SESSION_DURATION per user.
+        assert user_data["sessions"]["count"] == 1
+        assert user_data["sessions"]["total_duration"] == EXPECTED_SECONDS
+
+        # One job, spanning the whole session.
+        assert user_data["jobs"]["count"] == 1
+        assert len(user_data["jobs"]["stats"]) == 1
+        assert user_data["jobs"]["stats"][0]["total_duration"] == EXPECTED_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_acct_jobs_are_aligned_with_paginated_users(
+    client, app, serialized_sequence
+):
+    """Assert that job stats belong to the users on the returned page.
+
+    The sessions aggregation groups by user, the jobs aggregation groups by
+    (user, status). Paginating both with the same offset/limit only lines up
+    when every user has exactly one status, so we test by giving each user several.
+    """
+    N_USERS = 6
+    JOB_STATUSES = ("DONE", "ERROR", "CANCELED")
+    PAGINATION_LIMIT = 3
+    PAGINATION_OFFSET = 3
+    assert PAGINATION_LIMIT + PAGINATION_OFFSET <= N_USERS
+
+    user_uids, _, _ = await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        job_statuses=JOB_STATUSES,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT
+            + f"?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}"
+            + f"&offset={PAGINATION_OFFSET}"
+        )
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert len(data) == PAGINATION_LIMIT
+
+    expected_uids = user_uids[PAGINATION_OFFSET : PAGINATION_OFFSET + PAGINATION_LIMIT]
+    assert [user_data["user_id"] for user_data in data] == expected_uids
+
+    for user_data in data:
+        # Each user on the page owns exactly one job per status.
+        assert user_data["jobs"]["count"] == len(JOB_STATUSES), (
+            f"user {user_data['user_id']} reported {user_data['jobs']['count']} "
+            f"jobs, expected {len(JOB_STATUSES)}"
+        )
+        assert {stat["status"] for stat in user_data["jobs"]["stats"]} == set(
+            JOB_STATUSES
+        )
+        for stat in user_data["jobs"]["stats"]:
+            assert stat["count"] == 1

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -2,115 +2,85 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
 
 import pytest
-from httpx import AsyncClient
 
 from tests.api.conftest import acct_populate_db, mock_munge_auth
-from warden.api.schemas.acct import AcctRequest
 
 ACCT_ENDPOINT = "/accounting"
 ACCT_SESSIONS_ENDPOINT = "/accounting/sessions"
 ACCT_JOBS_ENDPOINT = "/accounting/jobs"
+ACCT_ENDPOINTS = [ACCT_ENDPOINT, ACCT_JOBS_ENDPOINT, ACCT_SESSIONS_ENDPOINT]
 
 
 @pytest.mark.asyncio
-async def test_acct_required_start(client: AsyncClient, app):
+@pytest.mark.parametrize("endpoint", ACCT_ENDPOINTS)
+async def test_acct_required_start(client, app, endpoint):
     """Assert that 'start_datetime' is required in the accounting data query."""
 
     with mock_munge_auth(app, uid=0):
-        response = await client.get(ACCT_ENDPOINT)
+        response = await client.get(endpoint)
     assert response.status_code == 422
 
     with mock_munge_auth(app, uid=0):
-        response = await client.get(ACCT_ENDPOINT + "?end_datetime=2022-01-01T00:00:00")
+        response = await client.get(endpoint + "?end_datetime=2022-01-01T00:00:00")
     assert response.status_code == 422
 
     with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_ENDPOINT + "?start_datetime=2022-01-01T00:00:00"
-        )
+        response = await client.get(endpoint + "?start_datetime=2022-01-01T00:00:00")
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_acct_nominal_pagination_filter(client, app, serialized_sequence):
-    """Assert that the accounting data query returns the right number of rows."""
+@pytest.mark.parametrize("endpoint", ACCT_ENDPOINTS)
+@pytest.mark.parametrize(
+    "query, expected_start, expected_end, expected_len, expected_first_index",
+    [
+        ("limit=100", 0, 10, 10, 0),
+        ("limit=5", 0, 5, 5, 0),
+        ("limit=5&offset=4", 4, 9, 5, 4),
+        ("offset=8", 8, 10, 2, 8),
+        # Offset past the end: the page is empty, and start/end are clamped to
+        # total so the response stays consistent (end - start == 0 items, never
+        # pointing beyond the data).
+        ("offset=20", 10, 10, 0, None),
+    ],
+)
+async def test_acct_pagination(
+    client,
+    app,
+    endpoint,
+    query,
+    expected_start,
+    expected_end,
+    expected_len,
+    expected_first_index,
+):
+    """Assert that the accounting data query returns the right number of rows for each of the endpoints.
+
+    We create 10 users, each with one session and one job in the session,
+    - /accounting
+    - /accounting/jobs
+    - /accounting/sessions
+    Then all have the same number of rows (10) so we can test their pagination similarly
+    """
     N_USERS = 10
 
-    user_uids, _, _ = await acct_populate_db(app, serialized_sequence, N_USERS)
-
-    # Test default
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
-        )
-    assert response.status_code == 200
-    assert response.json()["pagination"]["total"] == N_USERS
-    assert response.json()["pagination"]["start"] == 0
-    assert response.json()["pagination"]["end"] == N_USERS
-    assert len(response.json()["data"]) == N_USERS
-    assert response.json()["data"][0]["user_id"] == user_uids[0]
-
-    # Test pagination limit
-    PAGINATION_LIMIT = 5
-    assert PAGINATION_LIMIT < N_USERS
+    user_uids, _, _ = await acct_populate_db(app, N_USERS, job_statuses=("DONE",))
 
     with mock_munge_auth(app, uid=0):
         response = await client.get(
-            ACCT_ENDPOINT
-            + f"?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}"
+            endpoint + f"?start_datetime=2020-01-01T00:00:00&{query}"
         )
     assert response.status_code == 200
     assert response.json()["pagination"]["total"] == N_USERS
-    assert response.json()["pagination"]["start"] == 0
-    assert response.json()["pagination"]["end"] == PAGINATION_LIMIT
-    assert len(response.json()["data"]) == PAGINATION_LIMIT
-    assert response.json()["data"][0]["user_id"] == user_uids[0]
-
-    # Test offset
-    PAGINATION_LIMIT = 5
-    PAGINATION_OFFSET = 4
-    assert PAGINATION_LIMIT + PAGINATION_OFFSET < N_USERS
-
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_ENDPOINT
-            + f"?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}&offset={PAGINATION_OFFSET}"
-        )
-    assert response.status_code == 200
-    assert response.json()["pagination"]["total"] == N_USERS
-    assert response.json()["pagination"]["start"] == PAGINATION_OFFSET
-    assert response.json()["pagination"]["end"] == PAGINATION_LIMIT + PAGINATION_OFFSET
-    assert len(response.json()["data"]) == PAGINATION_LIMIT
-    assert response.json()["data"][0]["user_id"] == user_uids[PAGINATION_OFFSET]
-
-    # Test offset end of data length
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_ENDPOINT + f"?start_datetime=2020-01-01T00:00:00&offset={N_USERS - 2}"
-        )
-    assert response.status_code == 200
-    assert response.json()["pagination"]["total"] == N_USERS
-    assert response.json()["pagination"]["start"] == N_USERS - 2
-    assert response.json()["pagination"]["end"] == N_USERS
-    assert len(response.json()["data"]) == 2
-    assert response.json()["data"][0]["user_id"] == user_uids[N_USERS - 2]
-
-    # Test offset past the end: the page is empty, and start/end are clamped to
-    # total so the response stays consistent (end - start == 0 items, never
-    # pointing beyond the data).
-    with mock_munge_auth(app, uid=0):
-        response = await client.get(
-            ACCT_ENDPOINT + f"?start_datetime=2020-01-01T00:00:00&offset={N_USERS + 10}"
-        )
-    assert response.status_code == 200
-    assert response.json()["pagination"]["total"] == N_USERS
-    assert response.json()["pagination"]["start"] == N_USERS
-    assert response.json()["pagination"]["end"] == N_USERS
-    assert len(response.json()["data"]) == 0
+    assert response.json()["pagination"]["start"] == expected_start
+    assert response.json()["pagination"]["end"] == expected_end
+    assert len(response.json()["data"]) == expected_len
+    if expected_first_index is not None:
+        assert response.json()["data"][0]["user_id"] == user_uids[expected_first_index]
 
 
 @pytest.mark.asyncio
-async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
+async def test_acct_datetime_filter(client, app):
     """Assert that the accounting data query correctly filters according to start/end datetime."""
 
     N_USERS = 10
@@ -121,7 +91,6 @@ async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
 
     user_ids, _, sessions = await acct_populate_db(
         app,
-        serialized_sequence,
         first_session_start=FIRST_SESSION_START,
         n_users=N_USERS,
         session_duration=SESSION_DURATION,
@@ -178,35 +147,33 @@ async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
     assert len(response_after.json()["data"]) == 9
 
 
-def test_acct_request_normalizes_datetimes_to_naive_utc():
-    """The `start_datetime`/`end_datetime` validator must produce naive UTC
-    values regardless of the offset supplied by the caller, since not every
-    supported DB backend preserves timezone info on stored columns."""
+# def test_acct_request_normalizes_datetimes_to_naive_utc():
+#     """The `start_datetime`/`end_datetime` validator must produce naive UTC
+#     values regardless of the offset supplied by the caller, since not every
+#     supported DB backend preserves timezone info on stored columns."""
 
-    naive_utc = datetime(2026, 1, 1, 12, 0, 0)
-    aware_non_utc = naive_utc.replace(tzinfo=timezone(timedelta(hours=2))) + timedelta(
-        hours=2
-    )
+#     naive_utc = datetime(2026, 1, 1, 12, 0, 0)
+#     aware_non_utc = naive_utc.replace(tzinfo=timezone(timedelta(hours=2))) + timedelta(
+#         hours=2
+#     )
 
-    req = AcctRequest(start_datetime=aware_non_utc, end_datetime=aware_non_utc)
-    assert req.start_datetime == naive_utc
-    assert req.start_datetime.tzinfo is None
-    assert req.end_datetime == naive_utc
-    assert req.end_datetime.tzinfo is None
+#     req = AcctRequest(start_datetime=aware_non_utc, end_datetime=aware_non_utc)
+#     assert req.start_datetime == naive_utc
+#     assert req.start_datetime.tzinfo is None
+#     assert req.end_datetime == naive_utc
+#     assert req.end_datetime.tzinfo is None
 
-    # Naive input is assumed to already be UTC and passed through unchanged.
-    req_naive = AcctRequest(start_datetime=naive_utc)
-    assert req_naive.start_datetime == naive_utc
-    assert req_naive.start_datetime.tzinfo is None
+#     # Naive input is assumed to already be UTC and passed through unchanged.
+#     req_naive = AcctRequest(start_datetime=naive_utc)
+#     assert req_naive.start_datetime == naive_utc
+#     assert req_naive.start_datetime.tzinfo is None
 
-    # end_datetime is optional; None must pass through untouched.
-    assert req_naive.end_datetime is None
+#     # end_datetime is optional; None must pass through untouched.
+#     assert req_naive.end_datetime is None
 
 
 @pytest.mark.asyncio
-async def test_acct_datetime_filter_accepts_timezone_aware_query_params(
-    client, app, serialized_sequence
-):
+async def test_acct_datetime_filter_accepts_timezone_aware_query_params(client, app):
     """Assert that a start_datetime with a non-UTC offset selects the same
     rows as its naive-UTC equivalent, i.e. the request-level normalization
     is actually applied to query params, not just direct model usage."""
@@ -218,7 +185,6 @@ async def test_acct_datetime_filter_accepts_timezone_aware_query_params(
 
     _, _, sessions = await acct_populate_db(
         app,
-        serialized_sequence,
         first_session_start=FIRST_SESSION_START,
         n_users=N_USERS,
         session_duration=SESSION_DURATION,
@@ -255,7 +221,7 @@ async def test_acct_datetime_filter_accepts_timezone_aware_query_params(
 
 
 @pytest.mark.asyncio
-async def test_acct_reported_durations(client, app, serialized_sequence):
+async def test_acct_reported_durations(client, app):
     """Assert that reported session and job durations are the real elapsed seconds.
 
     The aggregation uses ``extract('epoch', ...)``, which only has the intended
@@ -267,7 +233,6 @@ async def test_acct_reported_durations(client, app, serialized_sequence):
 
     await acct_populate_db(
         app,
-        serialized_sequence,
         n_users=N_USERS,
         session_duration=SESSION_DURATION,
     )
@@ -294,9 +259,7 @@ async def test_acct_reported_durations(client, app, serialized_sequence):
 
 
 @pytest.mark.asyncio
-async def test_acct_jobs_are_aligned_with_paginated_users(
-    client, app, serialized_sequence
-):
+async def test_acct_jobs_are_aligned_with_paginated_users(client, app):
     """Assert that job stats belong to the users on the returned page.
 
     The sessions aggregation groups by user, the jobs aggregation groups by
@@ -311,7 +274,6 @@ async def test_acct_jobs_are_aligned_with_paginated_users(
 
     user_uids, _, _ = await acct_populate_db(
         app,
-        serialized_sequence,
         n_users=N_USERS,
         job_statuses=JOB_STATUSES,
     )
@@ -344,7 +306,7 @@ async def test_acct_jobs_are_aligned_with_paginated_users(
 
 
 @pytest.mark.asyncio
-async def test_acct_user_filtering(client, app, serialized_sequence):
+async def test_acct_user_filtering(client, app):
     """Assert that accounting data can be filtered by user"""
 
     N_USERS = 10
@@ -352,7 +314,6 @@ async def test_acct_user_filtering(client, app, serialized_sequence):
 
     user_uids, _, _ = await acct_populate_db(
         app,
-        serialized_sequence,
         n_users=N_USERS,
         job_statuses=JOB_STATUSES,
     )
@@ -401,14 +362,13 @@ async def test_acct_user_filtering(client, app, serialized_sequence):
 
 
 @pytest.mark.asyncio
-async def test_acct_jobs_user_filtering(client, app, serialized_sequence):
+async def test_acct_jobs_user_filtering(client, app):
     """Assert that /accounting/jobs filters by user and reports the right count."""
     N_USERS = 3
     JOB_STATUSES = ("DONE", "ERROR")
 
     user_uids, _, _ = await acct_populate_db(
         app,
-        serialized_sequence,
         n_users=N_USERS,
         job_statuses=JOB_STATUSES,
     )
@@ -428,14 +388,13 @@ async def test_acct_jobs_user_filtering(client, app, serialized_sequence):
 
 
 @pytest.mark.asyncio
-async def test_acct_jobs_session_id_filtering(client, app, serialized_sequence):
+async def test_acct_jobs_session_id_filtering(client, app):
     """Assert that /accounting/jobs can be filtered by session_id."""
     N_USERS = 2
     JOB_STATUSES = ("DONE", "ERROR")
 
     _, _, sessions = await acct_populate_db(
         app,
-        serialized_sequence,
         n_users=N_USERS,
         job_statuses=JOB_STATUSES,
     )
@@ -455,7 +414,7 @@ async def test_acct_jobs_session_id_filtering(client, app, serialized_sequence):
 
 
 @pytest.mark.asyncio
-async def test_acct_sessions_nominal(client, app, serialized_sequence):
+async def test_acct_sessions_nominal(client, app):
     """Assert that /accounting/sessions lists one row per session with its
     own duration and job count."""
     N_USERS = 4
@@ -464,7 +423,6 @@ async def test_acct_sessions_nominal(client, app, serialized_sequence):
 
     user_uids, _, sessions = await acct_populate_db(
         app,
-        serialized_sequence,
         n_users=N_USERS,
         session_duration=SESSION_DURATION,
         job_statuses=JOB_STATUSES,
@@ -489,7 +447,7 @@ async def test_acct_sessions_nominal(client, app, serialized_sequence):
 
 
 @pytest.mark.asyncio
-async def test_acct_jobs_nominal(client, app, serialized_sequence):
+async def test_acct_jobs_nominal(client, app):
     """Assert that /accounting/jobs lists one row per job with its own
     status and durations."""
     N_USERS = 2
@@ -497,7 +455,6 @@ async def test_acct_jobs_nominal(client, app, serialized_sequence):
 
     user_uids, jobs, _ = await acct_populate_db(
         app,
-        serialized_sequence,
         n_users=N_USERS,
         session_duration=SESSION_DURATION,
     )

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -1,9 +1,11 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
 
 import pytest
 from httpx import AsyncClient
 
 from tests.api.conftest import acct_populate_db, mock_munge_auth
+from warden.api.schemas.acct import AcctRequest
 
 ACCT_ENDPOINT = "/accounting"
 ACCT_SESSIONS_ENDPOINT = "/accounting/sessions"
@@ -174,6 +176,82 @@ async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
 
     assert len(response_before.json()["data"]) == 1
     assert len(response_after.json()["data"]) == 9
+
+
+def test_acct_request_normalizes_datetimes_to_naive_utc():
+    """The `start_datetime`/`end_datetime` validator must produce naive UTC
+    values regardless of the offset supplied by the caller, since not every
+    supported DB backend preserves timezone info on stored columns."""
+
+    naive_utc = datetime(2026, 1, 1, 12, 0, 0)
+    aware_non_utc = naive_utc.replace(tzinfo=timezone(timedelta(hours=2))) + timedelta(
+        hours=2
+    )
+
+    req = AcctRequest(start_datetime=aware_non_utc, end_datetime=aware_non_utc)
+    assert req.start_datetime == naive_utc
+    assert req.start_datetime.tzinfo is None
+    assert req.end_datetime == naive_utc
+    assert req.end_datetime.tzinfo is None
+
+    # Naive input is assumed to already be UTC and passed through unchanged.
+    req_naive = AcctRequest(start_datetime=naive_utc)
+    assert req_naive.start_datetime == naive_utc
+    assert req_naive.start_datetime.tzinfo is None
+
+    # end_datetime is optional; None must pass through untouched.
+    assert req_naive.end_datetime is None
+
+
+@pytest.mark.asyncio
+async def test_acct_datetime_filter_accepts_timezone_aware_query_params(
+    client, app, serialized_sequence
+):
+    """Assert that a start_datetime with a non-UTC offset selects the same
+    rows as its naive-UTC equivalent, i.e. the request-level normalization
+    is actually applied to query params, not just direct model usage."""
+
+    N_USERS = 10
+    FIRST_SESSION_START = datetime(2026, 1, 1, 0, 0, 0)
+    SESSION_DURATION = timedelta(minutes=45)
+    USER_TIME_OFFSET = timedelta(hours=1)
+
+    _, _, sessions = await acct_populate_db(
+        app,
+        serialized_sequence,
+        first_session_start=FIRST_SESSION_START,
+        n_users=N_USERS,
+        session_duration=SESSION_DURATION,
+        user_time_offset=USER_TIME_OFFSET,
+    )
+
+    second_session = sessions[1]
+    assert second_session.revoked_at is not None
+
+    # Same instant as `revoked_at` (naive, assumed UTC), expressed at UTC+2.
+    aware_equivalent = (second_session.revoked_at + timedelta(hours=2)).replace(
+        tzinfo=timezone(timedelta(hours=2))
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response_naive = await client.get(
+            ACCT_ENDPOINT
+            + "?start_datetime="
+            + second_session.revoked_at.isoformat()
+            + "&limit=100"
+        )
+        response_aware = await client.get(
+            ACCT_ENDPOINT
+            + "?start_datetime="
+            # `+` is form-encoding shorthand for a space in query strings, so
+            # a raw `+HH:MM` offset must be percent-encoded, same as any real
+            # HTTP client does automatically (e.g. httpx's `params=` kwarg).
+            + quote(aware_equivalent.isoformat())
+            + "&limit=100"
+        )
+    assert response_naive.status_code == 200
+    assert response_aware.status_code == 200
+    assert response_naive.json()["data"] == response_aware.json()["data"]
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -1,0 +1,95 @@
+"""Testing Job/Session model hybrid properties: instance-level vs SQL expression."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from warden.lib.models import Job, Session
+
+NOW = datetime(2026, 1, 1, 12, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_job_hybrid_properties_match_instance_and_expression(
+    app, serialized_sequence
+):
+    """Assert effective_end/execution_time/wait_time agree whether read on a
+    DB-loaded instance (Python getter) or computed by the SQL expression.
+
+    Uses whole-minute offsets so the comparison isn't sensitive to the
+    sub-second rounding differences duration_seconds has across backends.
+    """
+    session = Session(
+        created_at=NOW,
+        revoked_at=NOW + timedelta(hours=2),
+        user_id="1000",
+        slurm_job_id="0",
+    )
+    job = Job(
+        status="CANCELED",
+        logs="",
+        shots=100,
+        sequence=serialized_sequence,
+        created_at=NOW,
+        scheduled_at=NOW,
+        started_at=NOW + timedelta(minutes=5),
+        ended_at=None,
+        canceled_at=NOW + timedelta(minutes=35),
+        session=session,
+    )
+
+    session_factory = app.state.db_session_factory
+    async with session_factory() as db_session:
+        db_session.add_all([session, job])
+        await db_session.commit()
+        job_id = job.id
+
+    # Fresh session so `loaded_job` is actually read back from the DB,
+    # not the in-memory object we just built.
+    async with session_factory() as db_session:
+        loaded_job = await db_session.get(Job, job_id)
+
+        expr_stmt = select(
+            Job.effective_end,
+            Job.execution_time,
+            Job.wait_time,
+        ).where(Job.id == job_id)
+        row = (await db_session.execute(expr_stmt)).one()
+
+    assert loaded_job.effective_end == row.effective_end
+    assert loaded_job.execution_time == row.execution_time
+    assert loaded_job.wait_time == row.wait_time
+
+    # Pin the actual values, not just instance/expression agreement.
+    assert row.execution_time == 30 * 60
+    assert row.wait_time == 5 * 60
+
+
+@pytest.mark.asyncio
+async def test_session_duration_matches_instance_and_expression(app):
+    """Assert Session.duration agrees whether read on a DB-loaded instance
+    (Python getter) or computed by the SQL expression."""
+    session = Session(
+        created_at=NOW,
+        revoked_at=NOW + timedelta(minutes=45),
+        user_id="1000",
+        slurm_job_id="0",
+    )
+
+    session_factory = app.state.db_session_factory
+    async with session_factory() as db_session:
+        db_session.add(session)
+        await db_session.commit()
+        session_id = session.id
+
+    # Fresh session so `loaded_session` is actually read back from the DB,
+    # not the in-memory object we just built.
+    async with session_factory() as db_session:
+        loaded_session = await db_session.get(Session, session_id)
+
+        expr_stmt = select(Session.duration).where(Session.id == session_id)
+        row = (await db_session.execute(expr_stmt)).one()
+
+    assert loaded_session.duration == row.duration
+    assert row.duration == 45 * 60

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -299,6 +299,8 @@ async def test_run_job_timeout(
         - n(jobs !"PENDING") = N_JOBS
         - canceled_jobs_ids in JOB_TIMEOUT_CANCELED_ID
         - canceled_jobs have non-empty logs containing "Terminating"
+        - canceled_jobs have `ended_at` set, even though the mocked cancel
+          response never reports an end_datetime
         - done_jobs_ids not in JOB_TIMEOUT_CANCELED_ID
         - done_jobs_ids have non-empty logs
     """
@@ -478,6 +480,9 @@ async def test_run_job_timeout(
             assert job.id in JOB_TIMEOUT_CANCELED_ID
             assert len(job.logs) > 0
             assert "Terminating" in job.logs
+            # The mocked cancel response never reports an end_datetime; the
+            # worker must still backfill `ended_at` for the canceled job.
+            assert job.ended_at is not None
         job_done = (await session.execute(stmt_done)).scalars().all()
         for job in job_done:
             assert job.id not in JOB_TIMEOUT_CANCELED_ID

--- a/warden/api/app.py
+++ b/warden/api/app.py
@@ -2,7 +2,7 @@ import logging
 
 from fastapi import FastAPI
 
-from warden.api.routes import accessible, jobs, qpu, sessions
+from warden.api.routes import accessible, acct, jobs, qpu, sessions
 from warden.api.routes.dependencies.auth import init_auth
 from warden.api.routes.dependencies.db import init_db
 from warden.api.routes.dependencies.qpu_client import init_qpu_client
@@ -23,6 +23,7 @@ def create_app(config: Config):
     app.include_router(sessions.router, tags=["sessions"])
     app.include_router(qpu.router, tags=["qpu"])
     app.include_router(accessible.router, tags=["accessible"])
+    app.include_router(acct.router, tags=["accounting"])
 
     logger = logging.getLogger(__name__)
 

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -36,7 +36,12 @@ async def get_accounting_snapshot(
     db_session: DBSessionDep,
     _admin: AdminUserDep,
 ) -> GetAcctResponse:
-    """High-level accounting report"""
+    """Per-user accounting summary.
+
+    Aggregates session counts/duration and job counts/execution/wait time
+    and status per user, for sessions revoked within the requested time window.
+    One row per user paginated over the distinct set of users.
+    """
 
     # Base session filter
     db_query_filters = params.build_db_query_filters()
@@ -153,7 +158,12 @@ async def get_sessions_accounting(
     db_session: DBSessionDep,
     _admin: AdminUserDep,
 ) -> GetAcctSessionsResponse:
-    """Session-based accounting report"""
+    """Per-session accounting report.
+
+    Returns one row per session revoked within the requested time window,
+    with its duration and job count. Can additionally be filtered by
+    `slurm_job_id`.
+    """
 
     # Base session filter
     db_query_filters = params.build_db_query_filters()
@@ -209,11 +219,12 @@ async def get_jobs_accounting(
     db_session: DBSessionDep,
     _admin: AdminUserDep,
 ) -> GetAcctJobsResponse:
-    """Jobs-based accounting report.
+    """Per-job accounting report.
 
-    We use the same session-based time filtering as the other routes
-    for filtering consistency accross the routes. We then get jobs belonging to
-    the sessions filtered by the start/end datetimes query parameters
+    Returns one row per job **belonging to a session revoked within the
+    requested time window** (same session-based time filtering as the other
+    accounting routes, for consistency). Can additionally be filtered by
+    `session_id` and job `status`.
     """
 
     # Base session filter

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -36,7 +36,7 @@ async def get_accounting_snapshot(
     db_session: DBSessionDep,
     _admin: AdminUserDep,
 ) -> GetAcctResponse:
-    """High-level accounting data"""
+    """High-level accounting report"""
 
     # Base session filter
     session_filters = [Session.revoked_at >= params.start_datetime]
@@ -162,6 +162,8 @@ async def get_sessions_accounting(
     db_session: DBSessionDep,
     _admin: AdminUserDep,
 ) -> GetAcctSessionsResponse:
+    """Session-based accounting report"""
+
     # Base session filter
     session_filters = [Session.revoked_at >= params.start_datetime]
 
@@ -225,6 +227,7 @@ async def get_jobs_accounting(
     db_session: DBSessionDep,
     _admin: AdminUserDep,
 ) -> GetAcctJobsResponse:
+    """Jobs-based accounting report"""
 
     # Base jobs filter
     jobs_filter = [Job.effective_end >= params.start_datetime]
@@ -279,6 +282,7 @@ async def get_jobs_accounting(
             user_id=job_row.Job.user_id,
             session_id=job_row.Job.session_id,
             status=job_row.Job.status,
+            shots=job_row.Job.shots,
             execution_time=int(job_row.execution_time or 0),
             wait_time=int(job_row.wait_time or 0),
         )

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -196,7 +196,7 @@ async def get_sessions_accounting(
             Session.duration.label("total_session_duration"),
             func.count(Job.id).label("job_count"),
         )
-        .join(Job, Job.session_id == Session.id)
+        .outerjoin(Job, Job.session_id == Session.id)
         .group_by(Session.id)
         .where(and_(*session_filters))
         .order_by(Session.created_at)

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -59,10 +59,7 @@ async def get_accounting_snapshot(
         select(
             Session.user_id,
             func.count(Session.id).label("session_count"),
-            func.coalesce(
-                func.sum(Session.duration),
-                0,
-            ).label("total_session_duration"),
+            func.sum(Session.duration).label("total_session_duration"),
         )
         .where(and_(*session_filters))
         .group_by(Session.user_id)
@@ -193,7 +190,7 @@ async def get_sessions_accounting(
     sessions_stmt = (
         select(
             Session,
-            Session.duration.label("total_session_duration"),
+            Session.duration,
             func.count(Job.id).label("job_count"),
         )
         .outerjoin(Job, Job.session_id == Session.id)
@@ -210,7 +207,7 @@ async def get_sessions_accounting(
     return_data = []
     for session_row in sessions_data:
         session_data = SessionData.from_session_record(session_row.Session)
-        session_data.total_duration = int(session_row.total_session_duration)
+        session_data.total_duration = int(session_row.duration or 0)
         session_data.jobs_count = int(session_row.job_count)
         return_data.append(session_data)
     return GetAcctSessionsResponse(
@@ -263,8 +260,8 @@ async def get_jobs_accounting(
     jobs_stmt = (
         select(
             Job,
-            Job.execution_time.label("execution_time"),
-            Job.wait_time.label("wait_time"),
+            Job.execution_time,
+            Job.wait_time,
         )
         .where(and_(*jobs_filter))
         .order_by(Job.created_at)

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -23,7 +23,7 @@ from warden.lib.db.functions import duration_seconds
 from warden.lib.models import Job, Session
 
 logger = getLogger(__name__)
-router = APIRouter(prefix="/acct")
+router = APIRouter(prefix="/accounting")
 
 
 @router.get("")

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -1,9 +1,8 @@
 """Accounting information route"""
 
 from logging import getLogger
-from typing import Annotated
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter
 from sqlalchemy import and_, func, select
 
 from warden.api.routes.dependencies.auth import (
@@ -12,11 +11,17 @@ from warden.api.routes.dependencies.auth import (
 from warden.api.routes.dependencies.db import DBSessionDep
 from warden.api.schemas.acct import (
     AcctData,
-    GetAcctRequest,
+    GetAcctJobsRequestQueryParams,
+    GetAcctJobsResponse,
+    GetAcctRequestQueryParams,
     GetAcctResponse,
+    GetAcctSessionsRequestQueryParams,
+    GetAcctSessionsResponse,
+    JobData,
     JobsSummary,
     JobSummaryStats,
     PaginationResponse,
+    SessionData,
     SessionsSummary,
 )
 from warden.lib.db.functions import duration_seconds
@@ -28,7 +33,7 @@ router = APIRouter(prefix="/accounting")
 
 @router.get("")
 async def get_accounting_snapshot(
-    params: Annotated[GetAcctRequest, Query()],
+    params: GetAcctRequestQueryParams,
     db_session: DBSessionDep,
     _admin: AdminUserDep,
 ) -> GetAcctResponse:
@@ -155,4 +160,135 @@ async def get_accounting_snapshot(
     return GetAcctResponse(
         data=acct_data_list,
         pagination=pagination_resp,
+    )
+
+
+@router.get("/sessions")
+async def get_sessions_accounting(
+    params: GetAcctSessionsRequestQueryParams,
+    db_session: DBSessionDep,
+    _admin: AdminUserDep,
+) -> GetAcctSessionsResponse:
+    # Base session filter
+    session_filters = [Session.revoked_at >= params.start_datetime]
+
+    if params.end_datetime:
+        session_filters.append(Session.revoked_at < params.end_datetime)
+
+    if params.user_ids:
+        session_filters.append(Session.user_id.in_(params.user_ids))
+
+    if params.slurm_job_id:
+        session_filters.append(Session.slurm_job_id == params.slurm_job_id)
+
+    # Get total count for pagination
+    total_count_stmt = select(func.count(Session.id)).where(and_(*session_filters))
+    total_result = await db_session.execute(total_count_stmt)
+    total_count = total_result.scalar() or 0
+
+    if total_count == 0:
+        return GetAcctSessionsResponse(
+            data=[],
+            pagination=PaginationResponse.for_page(
+                offset=params.offset, count=0, total=total_count
+            ),
+        )
+
+    # Query to get sessions data aggregated by user_id
+    sessions_stmt = (
+        select(
+            Session,
+            duration_seconds(Session.created_at, Session.revoked_at).label(
+                "total_session_duration"
+            ),
+            func.count(Job.id).label("job_count"),
+        )
+        .join(Job, Job.session_id == Session.id)
+        .group_by(Session.id)
+        .where(and_(*session_filters))
+        .order_by(Session.created_at)
+        .offset(params.offset)
+        .limit(params.limit)
+    )
+
+    sessions_result = await db_session.execute(sessions_stmt)
+    sessions_data = sessions_result.fetchall()
+
+    return_data = []
+    for session_row in sessions_data:
+        session_data = SessionData.from_session_record(session_row.Session)
+        session_data.total_duration = int(session_row.total_session_duration)
+        session_data.jobs_count = int(session_row.job_count)
+        return_data.append(session_data)
+    return GetAcctSessionsResponse(
+        data=return_data,
+        pagination=PaginationResponse.for_page(
+            offset=params.offset, count=len(return_data), total=total_count
+        ),
+    )
+
+
+@router.get("/jobs")
+async def get_jobs_accounting(
+    params: GetAcctJobsRequestQueryParams,
+    db_session: DBSessionDep,
+    _admin: AdminUserDep,
+) -> GetAcctJobsResponse:
+
+    # Base jobs filter
+    jobs_filter = [Job.ended_at >= params.start_datetime]
+
+    if params.end_datetime:
+        jobs_filter.append(Job.ended_at < params.end_datetime)
+
+    if params.user_ids:
+        jobs_filter.append(Session.user_id.in_(params.user_ids))
+
+    # Get total count for pagination
+    total_count_stmt = select(func.count(Job.id)).where(and_(*jobs_filter))
+    total_result = await db_session.execute(total_count_stmt)
+    total_count = total_result.scalar() or 0
+
+    if total_count == 0:
+        return GetAcctSessionsResponse(
+            data=[],
+            pagination=PaginationResponse.for_page(
+                offset=params.offset, count=0, total=total_count
+            ),
+        )
+
+    jobs_stmt = (
+        select(
+            Job,
+            Session.user_id,
+            duration_seconds(Job.started_at, Job.ended_at).label("execution_time"),
+            duration_seconds(Job.created_at, Job.started_at).label("wait_time"),
+        )
+        .join(Session, Session.id == Job.session_id)
+        .group_by(Job.id)
+        .where(and_(*jobs_filter))
+        .order_by(Job.created_at)
+        .offset(params.offset)
+        .limit(params.limit)
+    )
+
+    jobs_result = await db_session.execute(jobs_stmt)
+    jobs_data = jobs_result.fetchall()
+
+    return_data = []
+    for job_row in jobs_data:
+        job_data = JobData(
+            id=job_row.Job.id,
+            user_id=job_row.user_id,
+            session_id=job_row.Job.session_id,
+            status=job_row.Job.status,
+            execution_time=job_row.execution_time,
+            wait_time=job_row.wait_time,
+        )
+        return_data.append(job_data)
+    return GetAcctJobsResponse(
+        data=return_data,
+        pagination=PaginationResponse.for_page(
+            offset=params.offset, count=len(return_data), total=total_count
+        ),
     )

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -1,0 +1,141 @@
+"""Accounting information route"""
+
+from logging import getLogger
+from typing import Annotated
+
+from fastapi import APIRouter, Query
+from sqlalchemy import and_, func, select
+
+from warden.api.routes.dependencies.auth import (
+    AdminUserDep,
+)
+from warden.api.routes.dependencies.db import DBSessionDep
+from warden.api.schemas.acct import (
+    AcctData,
+    GetAcctRequest,
+    GetAcctResponse,
+    JobsSummary,
+    JobSummaryStats,
+    PaginationResponse,
+    SessionsSummary,
+)
+from warden.lib.models import Job, Session
+
+logger = getLogger(__name__)
+router = APIRouter(prefix="/acct")
+
+
+@router.get("")
+async def get_accounting_snapshot(
+    params: Annotated[GetAcctRequest, Query()],
+    db_session: DBSessionDep,
+    _admin: AdminUserDep,
+) -> GetAcctResponse:
+    """High-level accounting data"""
+
+    # Base session filter
+    session_filters = [Session.revoked_at >= params.start_datetime]
+
+    if params.end_datetime:
+        session_filters.append(Session.revoked_at < params.end_datetime)
+
+    if params.user_ids:
+        session_filters.append(Session.user_id.in_(params.user_ids))
+
+    # Get total count for pagination
+    total_count_stmt = select(func.count(func.distinct(Session.user_id))).where(
+        and_(*session_filters)
+    )
+    total_result = await db_session.execute(total_count_stmt)
+    total_count = total_result.scalar() or 0
+
+    # Query to get sessions data aggregated by user_id
+    sessions_stmt = (
+        select(
+            Session.user_id,
+            func.count(Session.id).label("session_count"),
+            # Check
+            func.coalesce(
+                func.sum(
+                    func.extract("epoch", Session.revoked_at - Session.created_at)
+                ),
+                0,
+            ).label("total_session_duration"),
+        )
+        .where(and_(*session_filters))
+        .group_by(Session.user_id)
+        .order_by(Session.user_id)
+        .offset(params.offset)
+        .limit(params.limit)
+    )
+
+    sessions_result = await db_session.execute(sessions_stmt)
+    sessions_data = sessions_result.fetchall()
+
+    user_sessions_summary: dict[str, SessionsSummary] = {}
+
+    for session_row in sessions_data:
+        user_id = session_row.user_id
+        user_sessions_summary[user_id] = SessionsSummary(
+            count=session_row.session_count,
+            total_duration=session_row.total_session_duration,
+        )
+
+    # Query to get jobs data aggregated by user_id and job status
+    jobs_stmt = (
+        select(
+            Session.user_id,
+            Job.status,
+            func.count(Job.id).label("job_count"),
+            func.coalesce(
+                func.sum(func.extract("epoch", Job.ended_at - Job.started_at)), 0
+            ).label("total_job_duration"),
+        )
+        .join(Session, Session.id == Job.session_id, isouter=True)
+        .where(and_(*session_filters))
+        .group_by(Session.user_id, Job.status)
+        .order_by(Session.user_id)
+        .offset(params.offset)
+        .limit(params.limit)
+    )
+
+    jobs_result = await db_session.execute(jobs_stmt)
+    jobs_data = jobs_result.fetchall()
+
+    user_jobs_summaries: dict[str, JobsSummary] = {}
+
+    for job_row in jobs_data:
+        user_id = job_row.user_id
+        if user_id not in user_jobs_summaries:
+            user_jobs_summaries[user_id] = JobsSummary(count=0)
+        user_jobs_summaries[user_id].count += job_row.job_count
+        user_jobs_summaries[user_id].stats.append(
+            JobSummaryStats(
+                status=job_row.status,
+                count=job_row.job_count,
+                total_duration=int(job_row.total_job_duration or 0),
+            )
+        )
+
+    # For each user, get job statistics
+    acct_data_list = []
+
+    for user_id in user_sessions_summary.keys():
+        user_acct_data = AcctData(
+            user_id=user_id,
+            sessions=user_sessions_summary[user_id],
+            jobs=user_jobs_summaries.get(user_id, JobsSummary(count=0)),
+        )
+
+        acct_data_list.append(user_acct_data)
+
+    pagination_resp = PaginationResponse(
+        total=total_count,
+        start=params.offset,
+        end=min(params.offset + len(acct_data_list), total_count),
+    )
+
+    return GetAcctResponse(
+        data=acct_data_list,
+        pagination=pagination_resp,
+    )

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -100,7 +100,10 @@ async def get_accounting_snapshot(
             func.count(Job.id).label("job_count"),
             func.coalesce(
                 func.sum(duration_seconds(Job.started_at, Job.ended_at)), 0
-            ).label("total_job_duration"),
+            ).label("execution_time"),
+            func.coalesce(
+                func.sum(duration_seconds(Job.created_at, Job.started_at)), 0
+            ).label("wait_time"),
         )
         .join(Session, Session.id == Job.session_id)
         .where(
@@ -117,14 +120,19 @@ async def get_accounting_snapshot(
 
     for job_row in jobs_data:
         user_id = job_row.user_id
+        row_execution_time = int(job_row.execution_time)
+        row_wait_time = int(job_row.wait_time)
         if user_id not in user_jobs_summaries:
             user_jobs_summaries[user_id] = JobsSummary(count=0)
         user_jobs_summaries[user_id].count += job_row.job_count
+        user_jobs_summaries[user_id].execution_time += row_execution_time
+        user_jobs_summaries[user_id].wait_time += row_wait_time
         user_jobs_summaries[user_id].stats.append(
             JobSummaryStats(
                 status=job_row.status,
                 count=job_row.job_count,
-                total_duration=int(job_row.total_job_duration or 0),
+                execution_time=row_execution_time,
+                wait_time=row_wait_time,
             )
         )
 

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -24,7 +24,6 @@ from warden.api.schemas.acct import (
     SessionData,
     SessionsSummary,
 )
-from warden.lib.db.functions import duration_seconds
 from warden.lib.models import Job, Session
 
 logger = getLogger(__name__)
@@ -61,9 +60,7 @@ async def get_accounting_snapshot(
             Session.user_id,
             func.count(Session.id).label("session_count"),
             func.coalesce(
-                func.sum(
-                    duration_seconds(Session.created_at, Session.revoked_at),
-                ),
+                func.sum(Session.duration),
                 0,
             ).label("total_session_duration"),
         )
@@ -103,12 +100,8 @@ async def get_accounting_snapshot(
             Session.user_id,
             Job.status,
             func.count(Job.id).label("job_count"),
-            func.coalesce(
-                func.sum(duration_seconds(Job.started_at, Job.ended_at)), 0
-            ).label("execution_time"),
-            func.coalesce(
-                func.sum(duration_seconds(Job.created_at, Job.started_at)), 0
-            ).label("wait_time"),
+            func.coalesce(func.sum(Job.execution_time), 0).label("execution_time"),
+            func.coalesce(func.sum(Job.wait_time), 0).label("wait_time"),
         )
         .join(Session, Session.id == Job.session_id)
         .where(
@@ -198,9 +191,7 @@ async def get_sessions_accounting(
     sessions_stmt = (
         select(
             Session,
-            duration_seconds(Session.created_at, Session.revoked_at).label(
-                "total_session_duration"
-            ),
+            Session.duration.label("total_session_duration"),
             func.count(Job.id).label("job_count"),
         )
         .join(Job, Job.session_id == Session.id)
@@ -236,13 +227,19 @@ async def get_jobs_accounting(
 ) -> GetAcctJobsResponse:
 
     # Base jobs filter
-    jobs_filter = [Job.ended_at >= params.start_datetime]
+    jobs_filter = [Job.effective_end >= params.start_datetime]
 
     if params.end_datetime:
-        jobs_filter.append(Job.ended_at < params.end_datetime)
+        jobs_filter.append(Job.effective_end < params.end_datetime)
 
     if params.user_ids:
-        jobs_filter.append(Session.user_id.in_(params.user_ids))
+        jobs_filter.append(Job.user_id.in_(params.user_ids))
+
+    if params.session_id:
+        jobs_filter.append(Job.session_id == params.session_id)
+
+    if params.status:
+        jobs_filter.append(Job.status == params.status)
 
     # Get total count for pagination
     total_count_stmt = select(func.count(Job.id)).where(and_(*jobs_filter))
@@ -250,22 +247,22 @@ async def get_jobs_accounting(
     total_count = total_result.scalar() or 0
 
     if total_count == 0:
-        return GetAcctSessionsResponse(
+        return GetAcctJobsResponse(
             data=[],
             pagination=PaginationResponse.for_page(
                 offset=params.offset, count=0, total=total_count
             ),
         )
 
+    # Job.session is eagerly loaded (lazy="joined"), so Job.user_id (an
+    # association proxy to session.user_id) is available on each row without
+    # an extra join/select column here.
     jobs_stmt = (
         select(
             Job,
-            Session.user_id,
-            duration_seconds(Job.started_at, Job.ended_at).label("execution_time"),
-            duration_seconds(Job.created_at, Job.started_at).label("wait_time"),
+            Job.execution_time.label("execution_time"),
+            Job.wait_time.label("wait_time"),
         )
-        .join(Session, Session.id == Job.session_id)
-        .group_by(Job.id)
         .where(and_(*jobs_filter))
         .order_by(Job.created_at)
         .offset(params.offset)
@@ -279,11 +276,11 @@ async def get_jobs_accounting(
     for job_row in jobs_data:
         job_data = JobData(
             id=job_row.Job.id,
-            user_id=job_row.user_id,
+            user_id=job_row.Job.user_id,
             session_id=job_row.Job.session_id,
             status=job_row.Job.status,
-            execution_time=job_row.execution_time,
-            wait_time=job_row.wait_time,
+            execution_time=int(job_row.execution_time or 0),
+            wait_time=int(job_row.wait_time or 0),
         )
         return_data.append(job_data)
     return GetAcctJobsResponse(

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -39,17 +39,11 @@ async def get_accounting_snapshot(
     """High-level accounting report"""
 
     # Base session filter
-    session_filters = [Session.revoked_at >= params.start_datetime]
+    db_query_filters = params.build_db_query_filters()
 
-    if params.end_datetime:
-        session_filters.append(Session.revoked_at < params.end_datetime)
-
-    if params.user_ids:
-        session_filters.append(Session.user_id.in_(params.user_ids))
-
-    # Get total count for pagination
+    # Get total data row count for pagination
     total_count_stmt = select(func.count(func.distinct(Session.user_id))).where(
-        and_(*session_filters)
+        and_(*db_query_filters)
     )
     total_result = await db_session.execute(total_count_stmt)
     total_count = total_result.scalar() or 0
@@ -61,7 +55,7 @@ async def get_accounting_snapshot(
             func.count(Session.id).label("session_count"),
             func.sum(Session.duration).label("total_session_duration"),
         )
-        .where(and_(*session_filters))
+        .where(and_(*db_query_filters))
         .group_by(Session.user_id)
         .order_by(Session.user_id)
         .offset(params.offset)
@@ -102,7 +96,7 @@ async def get_accounting_snapshot(
         )
         .join(Session, Session.id == Job.session_id)
         .where(
-            and_(*session_filters, Session.user_id.in_(user_sessions_summary.keys()))
+            and_(*db_query_filters, Session.user_id.in_(user_sessions_summary.keys()))
         )
         .group_by(Session.user_id, Job.status)
         .order_by(Session.user_id)
@@ -162,19 +156,10 @@ async def get_sessions_accounting(
     """Session-based accounting report"""
 
     # Base session filter
-    session_filters = [Session.revoked_at >= params.start_datetime]
-
-    if params.end_datetime:
-        session_filters.append(Session.revoked_at < params.end_datetime)
-
-    if params.user_ids:
-        session_filters.append(Session.user_id.in_(params.user_ids))
-
-    if params.slurm_job_id:
-        session_filters.append(Session.slurm_job_id == params.slurm_job_id)
+    db_query_filters = params.build_db_query_filters()
 
     # Get total count for pagination
-    total_count_stmt = select(func.count(Session.id)).where(and_(*session_filters))
+    total_count_stmt = select(func.count(Session.id)).where(and_(*db_query_filters))
     total_result = await db_session.execute(total_count_stmt)
     total_count = total_result.scalar() or 0
 
@@ -195,7 +180,7 @@ async def get_sessions_accounting(
         )
         .outerjoin(Job, Job.session_id == Session.id)
         .group_by(Session.id)
-        .where(and_(*session_filters))
+        .where(and_(*db_query_filters))
         .order_by(Session.created_at)
         .offset(params.offset)
         .limit(params.limit)
@@ -224,28 +209,21 @@ async def get_jobs_accounting(
     db_session: DBSessionDep,
     _admin: AdminUserDep,
 ) -> GetAcctJobsResponse:
-    """Jobs-based accounting report"""
+    """Jobs-based accounting report.
+
+    We use the same session-based time filtering as the other routes
+    for filtering consistency accross the routes. We then get jobs belonging to
+    the sessions filtered by the start/end datetimes query parameters
+    """
 
     # Base session filter
-    filters = [Session.revoked_at >= params.start_datetime]
-
-    if params.end_datetime:
-        filters.append(Session.revoked_at < params.end_datetime)
-
-    if params.user_ids:
-        filters.append(Session.user_id.in_(params.user_ids))
-
-    if params.session_id:
-        filters.append(Session.id == params.session_id)
-
-    if params.status:
-        filters.append(Job.status == params.status)
+    db_query_filters = params.build_db_query_filters()
 
     # Get total count for pagination
     total_count_stmt = (
         select(func.count(Job.id))
         .join(Session, Session.id == Job.session_id)
-        .where(and_(*filters))
+        .where(and_(*db_query_filters))
     )
 
     total_result = await db_session.execute(total_count_stmt)
@@ -259,9 +237,6 @@ async def get_jobs_accounting(
             ),
         )
 
-    # Job.session is eagerly loaded (lazy="joined"), so Job.user_id (an
-    # association proxy to session.user_id) is available on each row without
-    # an extra join/select column here.
     jobs_stmt = (
         select(
             Job,
@@ -269,7 +244,7 @@ async def get_jobs_accounting(
             Job.wait_time,
         )
         .join(Session, Session.id == Job.session_id)
-        .where(and_(*filters))
+        .where(and_(*db_query_filters))
         .order_by(Job.created_at)
         .offset(params.offset)
         .limit(params.limit)

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -19,6 +19,7 @@ from warden.api.schemas.acct import (
     PaginationResponse,
     SessionsSummary,
 )
+from warden.lib.db.functions import duration_seconds
 from warden.lib.models import Job, Session
 
 logger = getLogger(__name__)
@@ -54,10 +55,9 @@ async def get_accounting_snapshot(
         select(
             Session.user_id,
             func.count(Session.id).label("session_count"),
-            # Check
             func.coalesce(
                 func.sum(
-                    func.extract("epoch", Session.revoked_at - Session.created_at)
+                    duration_seconds(Session.created_at, Session.revoked_at),
                 ),
                 0,
             ).label("total_session_duration"),
@@ -78,25 +78,36 @@ async def get_accounting_snapshot(
         user_id = session_row.user_id
         user_sessions_summary[user_id] = SessionsSummary(
             count=session_row.session_count,
-            total_duration=session_row.total_session_duration,
+            total_duration=int(session_row.total_session_duration or 0),
         )
 
-    # Query to get jobs data aggregated by user_id and job status
+    if not user_sessions_summary:
+        return GetAcctResponse(
+            data=[],
+            pagination=PaginationResponse.for_page(
+                offset=params.offset, count=0, total=total_count
+            ),
+        )
+
+    # Query to get jobs data aggregated by user_id and job status.
+    # This aggregation has one row per (user, status), so it cannot share the
+    # request's offset/limit with the sessions aggregation above. It is instead
+    # restricted to the users on the page that query just returned.
     jobs_stmt = (
         select(
             Session.user_id,
             Job.status,
             func.count(Job.id).label("job_count"),
             func.coalesce(
-                func.sum(func.extract("epoch", Job.ended_at - Job.started_at)), 0
+                func.sum(duration_seconds(Job.started_at, Job.ended_at)), 0
             ).label("total_job_duration"),
         )
-        .join(Session, Session.id == Job.session_id, isouter=True)
-        .where(and_(*session_filters))
+        .join(Session, Session.id == Job.session_id)
+        .where(
+            and_(*session_filters, Session.user_id.in_(user_sessions_summary.keys()))
+        )
         .group_by(Session.user_id, Job.status)
         .order_by(Session.user_id)
-        .offset(params.offset)
-        .limit(params.limit)
     )
 
     jobs_result = await db_session.execute(jobs_stmt)
@@ -129,10 +140,8 @@ async def get_accounting_snapshot(
 
         acct_data_list.append(user_acct_data)
 
-    pagination_resp = PaginationResponse(
-        total=total_count,
-        start=params.offset,
-        end=min(params.offset + len(acct_data_list), total_count),
+    pagination_resp = PaginationResponse.for_page(
+        offset=params.offset, count=len(acct_data_list), total=total_count
     )
 
     return GetAcctResponse(

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -226,23 +226,28 @@ async def get_jobs_accounting(
 ) -> GetAcctJobsResponse:
     """Jobs-based accounting report"""
 
-    # Base jobs filter
-    jobs_filter = [Job.effective_end >= params.start_datetime]
+    # Base session filter
+    filters = [Session.revoked_at >= params.start_datetime]
 
     if params.end_datetime:
-        jobs_filter.append(Job.effective_end < params.end_datetime)
+        filters.append(Session.revoked_at < params.end_datetime)
 
     if params.user_ids:
-        jobs_filter.append(Job.user_id.in_(params.user_ids))
+        filters.append(Session.user_id.in_(params.user_ids))
 
     if params.session_id:
-        jobs_filter.append(Job.session_id == params.session_id)
+        filters.append(Session.id == params.session_id)
 
     if params.status:
-        jobs_filter.append(Job.status == params.status)
+        filters.append(Job.status == params.status)
 
     # Get total count for pagination
-    total_count_stmt = select(func.count(Job.id)).where(and_(*jobs_filter))
+    total_count_stmt = (
+        select(func.count(Job.id))
+        .join(Session, Session.id == Job.session_id)
+        .where(and_(*filters))
+    )
+
     total_result = await db_session.execute(total_count_stmt)
     total_count = total_result.scalar() or 0
 
@@ -263,7 +268,8 @@ async def get_jobs_accounting(
             Job.execution_time,
             Job.wait_time,
         )
-        .where(and_(*jobs_filter))
+        .join(Session, Session.id == Job.session_id)
+        .where(and_(*filters))
         .order_by(Job.created_at)
         .offset(params.offset)
         .limit(params.limit)

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from warden.api.schemas.common import JobID, SessionID, UserID
+
+
+class PaginationResponse(BaseModel):
+    total: int
+    start: int
+    end: int
+
+
+class SessionsSummary(BaseModel):
+    count: int
+    total_duration: int
+
+
+class JobSummaryStats(BaseModel):
+    status: str
+    count: int
+    total_duration: int
+
+
+class JobsSummary(BaseModel):
+    count: int = Field(0, ge=0)
+    stats: list[JobSummaryStats] = Field(default_factory=list)
+
+
+class AcctData(BaseModel):
+    user_id: UserID
+    sessions: SessionsSummary
+    jobs: JobsSummary
+
+
+class AcctUserData(BaseModel):
+    pass
+
+
+class SessionsData(BaseModel):
+    id: SessionID
+    user_id: UserID
+    created_at: datetime
+    revoked_at: datetime | None
+    slurm_job_id: str
+
+
+class JobData(BaseModel):
+    id: JobID
+    user_id: UserID
+    session_id: SessionID
+    execution_time: int
+    status: str
+
+
+# Common parameters for request and response
+class AcctRequest(BaseModel):
+    # Time filtering
+    start_datetime: datetime
+    end_datetime: datetime | None = Field(default=None)
+    # Pagination
+    limit: int = Field(100, gt=0, le=100)
+    offset: int = Field(0, ge=0)
+
+
+class AcctResponse(BaseModel):
+    data: Any
+    pagination: PaginationResponse
+
+
+# Routes
+
+
+# GET /acct
+class GetAcctRequest(AcctRequest):
+    user_ids: set[UserID] | None = Field(default=None)
+
+
+class GetAcctResponse(AcctResponse):
+    data: list[AcctData]
+
+
+# GET /acct/user/{user_id}
+class GetAcctUserRequest(AcctRequest):
+    pass
+
+
+class GetAcctUserResponse(AcctResponse):
+    pass
+
+
+# GET /acct/jobs
+class GetAcctJobsRequest(AcctRequest):
+    session_id: SessionID | None
+    user_id: UserID | None
+
+
+class GetAcctJobsResponse(AcctResponse):
+    data: list[JobData]

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -130,6 +130,7 @@ GetAcctSessionsRequestQueryParams = Annotated[GetAcctSessionsRequest, Query()]
 # GET /accounting/jobs
 class GetAcctJobsRequest(AcctRequest):
     session_id: SessionID | None = Field(default=None)
+    status: str | None = Field(default=None)
 
 
 class GetAcctJobsResponse(AcctResponse):

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -11,6 +11,17 @@ class PaginationResponse(BaseModel):
     start: int
     end: int
 
+    @classmethod
+    def for_page(cls, *, offset: int, count: int, total: int) -> "PaginationResponse":
+        """Pagination for a page holding ``count`` items starting at ``offset``.
+
+        ``start`` is clamped to ``total`` so it never points beyond the data
+        (e.g. an offset past the end), which keeps the invariant
+        ``start <= end <= total`` and ``end - start == count``.
+        """
+        start = min(offset, total)
+        return cls(total=total, start=start, end=start + count)
+
 
 class SessionsSummary(BaseModel):
     count: int

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -31,11 +31,14 @@ class SessionsSummary(BaseModel):
 class JobSummaryStats(BaseModel):
     status: str
     count: int
-    total_duration: int
+    execution_time: int
+    wait_time: int
 
 
 class JobsSummary(BaseModel):
-    count: int = Field(0, ge=0)
+    count: int = Field(default=0, ge=0)
+    execution_time: int = Field(default=0, ge=0)
+    wait_time: int = Field(default=0, ge=0)
     stats: list[JobSummaryStats] = Field(default_factory=list)
 
 
@@ -71,8 +74,8 @@ class AcctRequest(BaseModel):
     start_datetime: datetime
     end_datetime: datetime | None = Field(default=None)
     # Pagination
-    limit: int = Field(100, gt=0, le=100)
-    offset: int = Field(0, ge=0)
+    limit: int = Field(default=100, gt=0, le=100)
+    offset: int = Field(default=0, ge=0)
 
 
 class AcctResponse(BaseModel):

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -86,13 +86,15 @@ class AcctRequest(BaseModel):
     user_ids: list[UserID] | None = Field(
         default=None,
         description="Restrict the report to these user IDs. Unset returns all users.",
+        examples=[["1000", "1001"]],
     )
     # Time filtering on the sessions end
     start_datetime: datetime = Field(
         description=(
             "Only include sessions revoked at or after this datetime. "
             "Naive datetimes are assumed to be UTC."
-        )
+        ),
+        examples=["2026-07-01T00:00:00Z"],
     )
     end_datetime: datetime | None = Field(
         default=None,
@@ -100,13 +102,21 @@ class AcctRequest(BaseModel):
             "Only include sessions revoked strictly before this datetime. "
             "Unset means no upper bound. Naive datetimes are assumed to be UTC."
         ),
+        examples=["2026-07-29T00:00:00Z"],
     )
     # Pagination
     limit: int = Field(
-        default=100, gt=0, le=100, description="Maximum number of rows to return."
+        default=100,
+        gt=0,
+        le=100,
+        description="Maximum number of rows to return.",
+        examples=[50],
     )
     offset: int = Field(
-        default=0, ge=0, description="Number of rows to skip, for pagination."
+        default=0,
+        ge=0,
+        description="Number of rows to skip, for pagination.",
+        examples=[0],
     )
 
     @field_validator("start_datetime", "end_datetime")
@@ -159,7 +169,9 @@ GetAcctRequestQueryParams = Annotated[AcctRequest, Query()]
 # GET /accounting/sessions
 class GetAcctSessionsRequest(AcctRequest):
     slurm_job_id: str | None = Field(
-        default=None, description="Restrict the report to this Slurm job ID."
+        default=None,
+        description="Restrict the report to this Slurm job ID.",
+        examples=["123456"],
     )
 
     def build_db_query_filters(self) -> list:
@@ -183,10 +195,14 @@ GetAcctSessionsRequestQueryParams = Annotated[GetAcctSessionsRequest, Query()]
 # GET /accounting/jobs
 class GetAcctJobsRequest(AcctRequest):
     session_id: SessionID | None = Field(
-        default=None, description="Restrict the report to this session ID."
+        default=None,
+        description="Restrict the report to this session ID.",
+        examples=["b3f1c2d4-5678-90ab-cdef-1234567890ab"],
     )
     status: str | None = Field(
-        default=None, description="Restrict the report to jobs with this status."
+        default=None,
+        description="Restrict the report to jobs with this status.",
+        examples=["ERROR"],
     )
 
     def build_db_query_filters(self) -> list:

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -79,6 +79,7 @@ class JobData(BaseModel):
     user_id: UserID
     session_id: SessionID
     status: str
+    shots: int
     execution_time: int
     wait_time: int
 

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -83,13 +83,31 @@ class JobData(BaseModel):
 # Common parameters for request and response
 class AcctRequest(BaseModel):
     # User filtering
-    user_ids: list[UserID] | None = Field(default=None)
+    user_ids: list[UserID] | None = Field(
+        default=None,
+        description="Restrict the report to these user IDs. Unset returns all users.",
+    )
     # Time filtering on the sessions end
-    start_datetime: datetime
-    end_datetime: datetime | None = Field(default=None)
+    start_datetime: datetime = Field(
+        description=(
+            "Only include sessions revoked at or after this datetime. "
+            "Naive datetimes are assumed to be UTC."
+        )
+    )
+    end_datetime: datetime | None = Field(
+        default=None,
+        description=(
+            "Only include sessions revoked strictly before this datetime. "
+            "Unset means no upper bound. Naive datetimes are assumed to be UTC."
+        ),
+    )
     # Pagination
-    limit: int = Field(default=100, gt=0, le=100)
-    offset: int = Field(default=0, ge=0)
+    limit: int = Field(
+        default=100, gt=0, le=100, description="Maximum number of rows to return."
+    )
+    offset: int = Field(
+        default=0, ge=0, description="Number of rows to skip, for pagination."
+    )
 
     @field_validator("start_datetime", "end_datetime")
     @classmethod
@@ -140,7 +158,9 @@ GetAcctRequestQueryParams = Annotated[AcctRequest, Query()]
 
 # GET /accounting/sessions
 class GetAcctSessionsRequest(AcctRequest):
-    slurm_job_id: str | None = Field(default=None)
+    slurm_job_id: str | None = Field(
+        default=None, description="Restrict the report to this Slurm job ID."
+    )
 
     def build_db_query_filters(self) -> list:
         """Build DB query filters from request query parameters"""
@@ -162,8 +182,12 @@ GetAcctSessionsRequestQueryParams = Annotated[GetAcctSessionsRequest, Query()]
 
 # GET /accounting/jobs
 class GetAcctJobsRequest(AcctRequest):
-    session_id: SessionID | None = Field(default=None)
-    status: str | None = Field(default=None)
+    session_id: SessionID | None = Field(
+        default=None, description="Restrict the report to this session ID."
+    )
+    status: str | None = Field(
+        default=None, description="Restrict the report to jobs with this status."
+    )
 
     def build_db_query_filters(self) -> list:
         """Build DB query filters from request query parameters"""

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -1,8 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Annotated, Any
 
 from fastapi import Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from warden.api.schemas.common import JobID, SessionID, UserID
 from warden.lib.models import Session
@@ -94,6 +94,19 @@ class AcctRequest(BaseModel):
     # Pagination
     limit: int = Field(default=100, gt=0, le=100)
     offset: int = Field(default=0, ge=0)
+
+    @field_validator("start_datetime", "end_datetime")
+    @classmethod
+    def _to_naive_utc(cls, value: datetime | None) -> datetime | None:
+        """Normalize to naive UTC, since not all supported DB backends
+        preserve tzinfo on the stored `DateTime(timezone=True)` columns.
+
+        Aware datetimes are converted to UTC and naive datetimes are assumed
+        to already be UTC.
+        """
+        if value is None or value.tzinfo is None:
+            return value
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 class AcctResponse(BaseModel):

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -83,7 +83,7 @@ class AcctResponse(BaseModel):
 # Routes
 
 
-# GET /acct
+# GET /accounting
 class GetAcctRequest(AcctRequest):
     user_ids: set[UserID] | None = Field(default=None)
 
@@ -92,7 +92,7 @@ class GetAcctResponse(AcctResponse):
     data: list[AcctData]
 
 
-# GET /acct/user/{user_id}
+# GET /accounting/user/{user_id}
 class GetAcctUserRequest(AcctRequest):
     pass
 
@@ -101,7 +101,7 @@ class GetAcctUserResponse(AcctResponse):
     pass
 
 
-# GET /acct/jobs
+# GET /accounting/jobs
 class GetAcctJobsRequest(AcctRequest):
     session_id: SessionID | None
     user_id: UserID | None

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -1,9 +1,11 @@
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any
 
+from fastapi import Query
 from pydantic import BaseModel, Field
 
 from warden.api.schemas.common import JobID, SessionID, UserID
+from warden.lib.models import Session
 
 
 class PaginationResponse(BaseModel):
@@ -52,24 +54,39 @@ class AcctUserData(BaseModel):
     pass
 
 
-class SessionsData(BaseModel):
+class SessionData(BaseModel):
     id: SessionID
     user_id: UserID
     created_at: datetime
     revoked_at: datetime | None
     slurm_job_id: str
+    total_duration: int = Field(default=0, ge=0)
+    jobs_count: int = Field(default=0, ge=0)
+
+    @classmethod
+    def from_session_record(cls, session: Session) -> "SessionData":
+        return cls(
+            id=session.id,
+            user_id=session.user_id,
+            created_at=session.created_at,
+            revoked_at=session.revoked_at,
+            slurm_job_id=session.slurm_job_id,
+        )
 
 
 class JobData(BaseModel):
     id: JobID
     user_id: UserID
     session_id: SessionID
-    execution_time: int
     status: str
+    execution_time: int
+    wait_time: int
 
 
 # Common parameters for request and response
 class AcctRequest(BaseModel):
+    # User filtering
+    user_ids: list[UserID] | None = Field(default=None)
     # Time filtering
     start_datetime: datetime
     end_datetime: datetime | None = Field(default=None)
@@ -88,27 +105,35 @@ class AcctResponse(BaseModel):
 
 # GET /accounting
 class GetAcctRequest(AcctRequest):
-    user_ids: list[UserID] | None = Field(default=None)
+    pass
 
 
 class GetAcctResponse(AcctResponse):
     data: list[AcctData]
 
 
-# GET /accounting/user/{user_id}
-class GetAcctUserRequest(AcctRequest):
-    pass
+GetAcctRequestQueryParams = Annotated[GetAcctRequest, Query()]
 
 
-class GetAcctUserResponse(AcctResponse):
-    pass
+# GET /accounting/sessions
+class GetAcctSessionsRequest(AcctRequest):
+    slurm_job_id: str | None = Field(default=None)
+
+
+class GetAcctSessionsResponse(AcctResponse):
+    data: list[SessionData]
+
+
+GetAcctSessionsRequestQueryParams = Annotated[GetAcctSessionsRequest, Query()]
 
 
 # GET /accounting/jobs
 class GetAcctJobsRequest(AcctRequest):
-    session_id: SessionID | None
-    user_id: UserID | None
+    session_id: SessionID | None = Field(default=None)
 
 
 class GetAcctJobsResponse(AcctResponse):
     data: list[JobData]
+
+
+GetAcctJobsRequestQueryParams = Annotated[GetAcctJobsRequest, Query()]

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -85,7 +85,7 @@ class AcctResponse(BaseModel):
 
 # GET /accounting
 class GetAcctRequest(AcctRequest):
-    user_ids: set[UserID] | None = Field(default=None)
+    user_ids: list[UserID] | None = Field(default=None)
 
 
 class GetAcctResponse(AcctResponse):

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -93,16 +93,20 @@ class AcctRequest(BaseModel):
 
     @field_validator("start_datetime", "end_datetime")
     @classmethod
-    def _to_naive_utc(cls, value: datetime | None) -> datetime | None:
-        """Normalize to naive UTC, since not all supported DB backends
-        preserve tzinfo on the stored `DateTime(timezone=True)` columns.
+    def _to_utc(cls, value: datetime | None) -> datetime | None:
+        """Normalize to UTC, since not all supported DB backends
+        preserve tzinfo on the stored `DateTime(timezone=True)` columns
+        but keep UTC tz info for postgres backend.
 
         Aware datetimes are converted to UTC and naive datetimes are assumed
         to already be UTC.
         """
-        if value is None or value.tzinfo is None:
-            return value
-        return value.astimezone(timezone.utc).replace(tzinfo=None)
+        if value is None:
+            return None
+        elif value.tzinfo is None:
+            # Assumed to be UTC
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
 
 class AcctResponse(BaseModel):

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -5,7 +5,7 @@ from fastapi import Query
 from pydantic import BaseModel, Field, field_validator
 
 from warden.api.schemas.common import JobID, SessionID, UserID
-from warden.lib.models import Session
+from warden.lib.models import Job, Session
 
 
 class PaginationResponse(BaseModel):
@@ -108,6 +108,19 @@ class AcctRequest(BaseModel):
             return value.replace(tzinfo=timezone.utc)
         return value.astimezone(timezone.utc)
 
+    def build_db_query_filters(self) -> list:
+        """Build DB query filters from request query parameters"""
+        # Base session filter
+        filters = [Session.revoked_at >= self.start_datetime]
+
+        if self.end_datetime:
+            filters.append(Session.revoked_at < self.end_datetime)
+
+        if self.user_ids:
+            filters.append(Session.user_id.in_(self.user_ids))
+
+        return filters
+
 
 class AcctResponse(BaseModel):
     data: Any
@@ -129,6 +142,16 @@ GetAcctRequestQueryParams = Annotated[AcctRequest, Query()]
 class GetAcctSessionsRequest(AcctRequest):
     slurm_job_id: str | None = Field(default=None)
 
+    def build_db_query_filters(self) -> list:
+        """Build DB query filters from request query parameters"""
+
+        filters = super().build_db_query_filters()
+
+        if self.slurm_job_id:
+            filters.append(Session.slurm_job_id == self.slurm_job_id)
+
+        return filters
+
 
 class GetAcctSessionsResponse(AcctResponse):
     data: list[SessionData]
@@ -141,6 +164,19 @@ GetAcctSessionsRequestQueryParams = Annotated[GetAcctSessionsRequest, Query()]
 class GetAcctJobsRequest(AcctRequest):
     session_id: SessionID | None = Field(default=None)
     status: str | None = Field(default=None)
+
+    def build_db_query_filters(self) -> list:
+        """Build DB query filters from request query parameters"""
+
+        filters = super().build_db_query_filters()
+
+        if self.session_id:
+            filters.append(Session.id == self.session_id)
+
+        if self.status:
+            filters.append(Job.status == self.status)
+
+        return filters
 
 
 class GetAcctJobsResponse(AcctResponse):

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -50,10 +50,6 @@ class AcctData(BaseModel):
     jobs: JobsSummary
 
 
-class AcctUserData(BaseModel):
-    pass
-
-
 class SessionData(BaseModel):
     id: SessionID
     user_id: UserID
@@ -118,15 +114,11 @@ class AcctResponse(BaseModel):
 
 
 # GET /accounting
-class GetAcctRequest(AcctRequest):
-    pass
-
-
 class GetAcctResponse(AcctResponse):
     data: list[AcctData]
 
 
-GetAcctRequestQueryParams = Annotated[GetAcctRequest, Query()]
+GetAcctRequestQueryParams = Annotated[AcctRequest, Query()]
 
 
 # GET /accounting/sessions

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -84,7 +84,7 @@ class JobData(BaseModel):
 class AcctRequest(BaseModel):
     # User filtering
     user_ids: list[UserID] | None = Field(default=None)
-    # Time filtering
+    # Time filtering on the sessions end
     start_datetime: datetime
     end_datetime: datetime | None = Field(default=None)
     # Pagination

--- a/warden/api/schemas/common.py
+++ b/warden/api/schemas/common.py
@@ -1,0 +1,8 @@
+"""Common definitions"""
+
+from typing import TypeAlias
+from uuid import UUID
+
+SessionID: TypeAlias = UUID
+UserID: TypeAlias = str
+JobID: TypeAlias = int

--- a/warden/api/schemas/jobs.py
+++ b/warden/api/schemas/jobs.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, Union
 
 from pydantic import BaseModel, Field, ValidationError
 
+from warden.api.schemas.common import UserID
 from warden.lib.models.jobs import Job
 
 
@@ -23,7 +24,7 @@ class JobCreate(BaseModel):
 
 class JobResponse(BaseModel):
     id: int
-    user_id: str
+    user_id: UserID
     created_at: datetime
     status: str
     results: str | None

--- a/warden/api/schemas/sessions.py
+++ b/warden/api/schemas/sessions.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from uuid import UUID
 
 from pydantic import BaseModel
 
+from warden.api.schemas.common import SessionID, UserID
 from warden.lib.models.sessions import Session
 
 
@@ -12,8 +12,8 @@ class CreateSession(BaseModel):
 
 
 class SessionResponse(BaseModel):
-    id: UUID
-    user_id: str
+    id: SessionID
+    user_id: UserID
     created_at: datetime
     revoked_at: datetime | None
 

--- a/warden/lib/db/functions.py
+++ b/warden/lib/db/functions.py
@@ -1,0 +1,54 @@
+"""Portable SQL expressions.
+
+Warden supports SQLite, PostgreSQL and MariaDB, which do not share a way to
+express an elapsed duration between two datetime columns. These helpers compile
+to the right expression per dialect.
+"""
+
+from sqlalchemy import Numeric, func, text
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import FunctionElement
+
+
+class duration_seconds(FunctionElement):
+    """Seconds elapsed between two datetime columns.
+
+    Usage: ``duration_seconds(started_at, ended_at)``. NULL on either side
+    yields NULL, so it composes with ``func.sum`` the usual way.
+    """
+
+    type = Numeric()
+    inherit_cache = True
+    name = "duration_seconds"
+
+
+@compiles(duration_seconds, "postgresql")
+def _duration_seconds_postgresql(element, compiler, **kw):
+    start, end = list(element.clauses)
+    return compiler.process(func.extract("epoch", end - start), **kw)
+
+
+@compiles(duration_seconds, "sqlite")
+def _duration_seconds_sqlite(element, compiler, **kw):
+    # SQLite has no interval type: subtracting datetimes coerces them to
+    # numbers. julianday() gives fractional days, which we scale to seconds.
+    # The scaling is lossy in binary floating point (an exact hour comes back
+    # as 3599.999...), so round to whole seconds like the other backends.
+    start, end = list(element.clauses)
+    return compiler.process(
+        func.round((func.julianday(end) - func.julianday(start)) * 86400.0), **kw
+    )
+
+
+@compiles(duration_seconds, "mysql")
+def _duration_seconds_mysql(element, compiler, **kw):
+    # MariaDB is served by the mysql dialect. EXTRACT has no epoch unit here.
+    start, end = list(element.clauses)
+    return compiler.process(func.timestampdiff(text("SECOND"), start, end), **kw)
+
+
+@compiles(duration_seconds)
+def _duration_seconds_default(element, compiler, **kw):
+    raise NotImplementedError(
+        f"duration_seconds() is not implemented for dialect {compiler.dialect.name!r}."
+    )

--- a/warden/lib/models/jobs.py
+++ b/warden/lib/models/jobs.py
@@ -109,7 +109,7 @@ class Job(Base):
         """Seconds from started_at to effective_end, or None if either is unset."""
         if self.started_at is None or self.effective_end is None:
             return None
-        return (self.effective_end - self.started_at).total_seconds()
+        return int((self.effective_end - self.started_at).total_seconds())
 
     @execution_time.inplace.expression
     @classmethod
@@ -122,7 +122,7 @@ class Job(Base):
         """Seconds from created_at to started_at, or None if not started yet."""
         if self.started_at is None:
             return None
-        return (self.started_at - self.created_at).total_seconds()
+        return int((self.started_at - self.created_at).total_seconds())
 
     @wait_time.inplace.expression
     @classmethod

--- a/warden/lib/models/jobs.py
+++ b/warden/lib/models/jobs.py
@@ -7,11 +7,14 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    func,
 )
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from warden.lib.db.database import Base
+from warden.lib.db.functions import duration_seconds
 from warden.lib.models.sessions import Session
 
 
@@ -89,3 +92,40 @@ class Job(Base):
         "session",
         "user_id",
     )
+
+    @hybrid_property
+    def effective_end(self):
+        """ended_at, or canceled_at if the job was canceled before ended_at
+        was recorded."""
+        return self.ended_at or self.canceled_at
+
+    @effective_end.inplace.expression
+    @classmethod
+    def _effective_end_expression(cls):
+        return func.coalesce(cls.ended_at, cls.canceled_at)
+
+    @hybrid_property
+    def execution_time(self):
+        """Seconds from started_at to effective_end, or None if either is unset."""
+        if self.started_at is None or self.effective_end is None:
+            return None
+        return (self.effective_end - self.started_at).total_seconds()
+
+    @execution_time.inplace.expression
+    @classmethod
+    def _execution_time_expression(cls):
+        """SQL expression: seconds from started_at to effective_end."""
+        return duration_seconds(cls.started_at, cls.effective_end)
+
+    @hybrid_property
+    def wait_time(self):
+        """Seconds from created_at to started_at, or None if not started yet."""
+        if self.started_at is None:
+            return None
+        return (self.started_at - self.created_at).total_seconds()
+
+    @wait_time.inplace.expression
+    @classmethod
+    def _wait_time_expression(cls):
+        """SQL expression: seconds from created_at to started_at."""
+        return duration_seconds(cls.created_at, cls.started_at)

--- a/warden/lib/models/sessions.py
+++ b/warden/lib/models/sessions.py
@@ -9,9 +9,11 @@ from sqlalchemy import (
     DateTime,
     String,
 )
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column
 
 from warden.lib.db.database import Base
+from warden.lib.db.functions import duration_seconds
 
 
 class Session(Base):
@@ -33,3 +35,15 @@ class Session(Base):
     slurm_job_id: Mapped[str] = mapped_column(
         String(255), doc="ID of the slurm job which created this session."
     )
+
+    @hybrid_property
+    def duration(self):
+        if self.revoked_at is None:
+            return None
+        return (self.revoked_at - self.created_at).total_seconds()
+
+    @duration.inplace.expression
+    @classmethod
+    def _duration_expression(cls):
+        """SQL expression: seconds between created_at and revoked_at (NULL if active)."""
+        return duration_seconds(cls.created_at, cls.revoked_at)

--- a/warden/lib/models/sessions.py
+++ b/warden/lib/models/sessions.py
@@ -40,7 +40,7 @@ class Session(Base):
     def duration(self):
         if self.revoked_at is None:
             return None
-        return (self.revoked_at - self.created_at).total_seconds()
+        return int((self.revoked_at - self.created_at).total_seconds())
 
     @duration.inplace.expression
     @classmethod

--- a/warden/lib/qpu_client/types.py
+++ b/warden/lib/qpu_client/types.py
@@ -9,7 +9,7 @@ JobStatus: TypeAlias = Literal["PENDING", "RUNNING", "ERROR", "CANCELED", "DONE"
 QPUStatus: TypeAlias = Literal["UP", "DOWN"]
 
 
-@dataclass(frozen=True)
+@dataclass
 class QPUJobInfo:
     uid: int
     batch_id: str | None

--- a/warden/scheduler/worker.py
+++ b/warden/scheduler/worker.py
@@ -239,7 +239,6 @@ class LocalQPUWorker:
                     await job_tracker.to_error()
                     continue
                 logger.info("Job cancellation done")
-                # TODO: Ensure ended_at here and ping pasqos
                 continue
             await asyncio.sleep(self.conf_sched.job_polling_interval_s)
             await self._get_job_poll(job_tracker)

--- a/warden/scheduler/worker.py
+++ b/warden/scheduler/worker.py
@@ -52,7 +52,7 @@ class JobExecutionTracker:
     def created_datetime(self) -> UTCDatetime:
         return self.job.created_datetime
 
-      async def update_job(
+    async def update_job(
         self, qpu_job_info: QPUJobInfo, enforce_end_datetime: bool = False
     ):
         self._qpu_job_info = qpu_job_info

--- a/warden/scheduler/worker.py
+++ b/warden/scheduler/worker.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 
 from warden.lib.config import Config
 from warden.lib.qpu_client import (
@@ -43,9 +43,17 @@ class JobExecutionTracker:
     def is_error(self) -> bool:
         return self.status == "ERROR"
 
-    async def update_job(self, qpu_job_info: QPUJobInfo):
+    @property
+    def is_in_terminal_state(self) -> bool:
+        return self.status in ("DONE", "CANCELED", "ERROR")
+
+    async def update_job(
+        self, qpu_job_info: QPUJobInfo, enforce_end_datetime: bool = False
+    ):
         self._qpu_job_info = qpu_job_info
         self._status = qpu_job_info.status or "ERROR"
+        if enforce_end_datetime and self._qpu_job_info.end_datetime is None:
+            self._qpu_job_info.end_datetime = datetime.now(timezone.utc)
         await self.push_update()
 
     async def to_error(self):
@@ -214,7 +222,7 @@ class LocalQPUWorker:
         """Polling the job status until completion, error, or cancellation"""
         polling_start = datetime.now()
         await self._get_job_poll(job_tracker)
-        while job_tracker.status not in ("ERROR", "DONE", "CANCELED"):
+        while not job_tracker.is_in_terminal_state:
             if self.is_timed_out(self.conf_sched.job_polling_timeout_s, polling_start):
                 logger.warning(
                     f"Job timed out (max {self.conf_sched.job_polling_timeout_s} s). "
@@ -223,12 +231,15 @@ class LocalQPUWorker:
                 )
                 try:
                     qpu_job_info = self.qpu_client.cancel_job(job_tracker.job.uid)
-                    await job_tracker.update_job(qpu_job_info)
+                    await job_tracker.update_job(
+                        qpu_job_info, enforce_end_datetime=True
+                    )
                 except (JobCancelationError, QPUClientRequestError) as e:
                     logger.error(f"Failed cancelling job: {e}")
                     await job_tracker.to_error()
                     continue
                 logger.info("Job cancellation done")
+                # TODO: Ensure ended_at here and ping pasqos
                 continue
             await asyncio.sleep(self.conf_sched.job_polling_interval_s)
             await self._get_job_poll(job_tracker)


### PR DESCRIPTION
Adds a set of accounting/usage-reporting endpoints to Warden so admins can query per-user, per-session, and per-job usage over a requested time period.

# Added 

`/accounting` API. Generates usage reports over a specified time window. The time window is delimited by query parameters `start_datetime` and `end_datetime` (optional) that select sessions revoked during this time-period, so every data returned by the accounting API (whether it is job-based or -user-based) correspond to jobs/user activity associated with sessions filtered by the `start/end_datetime` parameters. Also supports `user_ids` filtering and data pagination.

- `GET /accounting`
  - Per user summary of sessions and job duration.
- `GET /accounting/sessions`
  - Per session accounting information
  - Also supports `slurm_job_id` filtering
- `GET /accounting/jobs`
  - Per job accounting information
  - Also supports `status` and `session_id` filtering

Added small section to `README.md` about the new accounting API routes and informs users to refer to the `/docs` documentation generated by FastAPI.

# Modified
- Enforce an `ended_at` datetime when canceling a job due to timeout in case QPU API fails to return one in `warden/scheduler/worker.py`, in which case a job would have neither a `ended_at` or `canceled_at` datetime to calculate accounting data further down in time.
- Added hybrid properties to `Jobs` and `Sessions` models to support instance or in-db duration calculation.

# TODO

- [x] In Jobs table, if no `ended_at` replace by `canceled_at`
- [ ] Investigate failed test: https://github.com/pasqal-io/warden/actions/runs/30021583810/job/89255393221?pr=71