### PR TITLE
test(acct): Regression tests for durations and jobs pagination

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,7 +1,7 @@
 import json
 from contextlib import contextmanager
 from datetime import datetime, timedelta
-from typing import AsyncGenerator, Callable, Generator
+from typing import AsyncGenerator, Callable, Generator, Sequence
 
 import pytest
 import pytest_asyncio
@@ -260,8 +260,14 @@ async def acct_populate_db(
     first_session_start: datetime = datetime(2026, 1, 1, 0, 0, 0),
     session_duration: timedelta = timedelta(hours=1),
     user_time_offset: timedelta = timedelta(hours=1),
+    job_statuses: Sequence[str] = ("DONE",),
 ) -> tuple[list[str], list[Job], list[Session]]:
-    """Creates mock data for accounting testing in DB"""
+    """Creates mock data for accounting testing in DB
+
+    One session per user, and one job per entry in ``job_statuses`` per user.
+    Passing several statuses makes the jobs aggregation produce more rows than
+    the sessions aggregation, which is what exercises their pagination.
+    """
     BASE_START_DATETIME = first_session_start
     BASE_END_DATETIME = BASE_START_DATETIME + session_duration
     user_uids = [str(i) for i in range(1000, 1000 + n_users)]
@@ -281,20 +287,21 @@ async def acct_populate_db(
                 slurm_job_id=str(i),
             )
         )
-        jobs.append(
-            Job(
-                status="DONE",
-                logs="",
-                shots=100,
-                sequence=serialized_sequence,
-                created_at=start_session,
-                scheduled_at=start_session,
-                started_at=start_session,
-                ended_at=end_session,
-                # Relationship
-                session=sessions[-1],
+        for status in job_statuses:
+            jobs.append(
+                Job(
+                    status=status,
+                    logs="",
+                    shots=100,
+                    sequence=serialized_sequence,
+                    created_at=start_session,
+                    scheduled_at=start_session,
+                    started_at=start_session,
+                    ended_at=end_session,
+                    # Relationship
+                    session=sessions[-1],
+                )
             )
-        )
 
     async_session_factory = app.state.db_session_factory
     async with async_session_factory() as db_session:

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -220,7 +220,7 @@ async def test_acct_jobs_are_aligned_with_paginated_users(
 
     The sessions aggregation groups by user, the jobs aggregation groups by
     (user, status). Paginating both with the same offset/limit only lines up
-    when every user has exactly one status, so give each user several.
+    when every user has exactly one status, so we test by giving each user several.
     """
     N_USERS = 6
     JOB_STATUSES = ("DONE", "ERROR", "CANCELED")

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -159,3 +159,91 @@ async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):
 
     assert len(response_before.json()["data"]) == 1
     assert len(response_after.json()["data"]) == 9
+
+
+@pytest.mark.asyncio
+async def test_acct_reported_durations(client, app, serialized_sequence):
+    """Assert that reported session and job durations are the real elapsed seconds.
+
+    The aggregation uses ``extract('epoch', ...)``, which only has the intended
+    meaning on PostgreSQL. This pins the value on every supported backend.
+    """
+    N_USERS = 3
+    SESSION_DURATION = timedelta(hours=1)
+    EXPECTED_SECONDS = int(SESSION_DURATION.total_seconds())
+
+    await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        session_duration=SESSION_DURATION,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT + "?start_datetime=2020-01-01T00:00:00&limit=100"
+        )
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert len(data) == N_USERS
+
+    for user_data in data:
+        # One session of SESSION_DURATION per user.
+        assert user_data["sessions"]["count"] == 1
+        assert user_data["sessions"]["total_duration"] == EXPECTED_SECONDS
+
+        # One job, spanning the whole session.
+        assert user_data["jobs"]["count"] == 1
+        assert len(user_data["jobs"]["stats"]) == 1
+        assert user_data["jobs"]["stats"][0]["total_duration"] == EXPECTED_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_acct_jobs_are_aligned_with_paginated_users(
+    client, app, serialized_sequence
+):
+    """Assert that job stats belong to the users on the returned page.
+
+    The sessions aggregation groups by user, the jobs aggregation groups by
+    (user, status). Paginating both with the same offset/limit only lines up
+    when every user has exactly one status, so give each user several.
+    """
+    N_USERS = 6
+    JOB_STATUSES = ("DONE", "ERROR", "CANCELED")
+    PAGINATION_LIMIT = 3
+    PAGINATION_OFFSET = 3
+    assert PAGINATION_LIMIT + PAGINATION_OFFSET <= N_USERS
+
+    user_uids, _, _ = await acct_populate_db(
+        app,
+        serialized_sequence,
+        n_users=N_USERS,
+        job_statuses=JOB_STATUSES,
+    )
+
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT
+            + f"?start_datetime=2020-01-01T00:00:00&limit={PAGINATION_LIMIT}"
+            + f"&offset={PAGINATION_OFFSET}"
+        )
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert len(data) == PAGINATION_LIMIT
+
+    expected_uids = user_uids[PAGINATION_OFFSET : PAGINATION_OFFSET + PAGINATION_LIMIT]
+    assert [user_data["user_id"] for user_data in data] == expected_uids
+
+    for user_data in data:
+        # Each user on the page owns exactly one job per status.
+        assert user_data["jobs"]["count"] == len(JOB_STATUSES), (
+            f"user {user_data['user_id']} reported {user_data['jobs']['count']} "
+            f"jobs, expected {len(JOB_STATUSES)}"
+        )
+        assert {stat["status"] for stat in user_data["jobs"]["stats"]} == set(
+            JOB_STATUSES
+        )
+        for stat in user_data["jobs"]["stats"]:
+            assert stat["count"] == 1

--- a/tests/api/test_acct.py
+++ b/tests/api/test_acct.py
@@ -91,6 +91,19 @@ async def test_acct_nominal_pagination_filter(client, app, serialized_sequence):
     assert len(response.json()["data"]) == 2
     assert response.json()["data"][0]["user_id"] == user_uids[N_USERS - 2]
 
+    # Test offset past the end: the page is empty, and start/end are clamped to
+    # total so the response stays consistent (end - start == 0 items, never
+    # pointing beyond the data).
+    with mock_munge_auth(app, uid=0):
+        response = await client.get(
+            ACCT_ENDPOINT + f"?start_datetime=2020-01-01T00:00:00&offset={N_USERS + 10}"
+        )
+    assert response.status_code == 200
+    assert response.json()["pagination"]["total"] == N_USERS
+    assert response.json()["pagination"]["start"] == N_USERS
+    assert response.json()["pagination"]["end"] == N_USERS
+    assert len(response.json()["data"]) == 0
+
 
 @pytest.mark.asyncio
 async def test_acct_nominal_datetime_filter(client, app, serialized_sequence):

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -19,6 +19,7 @@ from warden.api.schemas.acct import (
     PaginationResponse,
     SessionsSummary,
 )
+from warden.lib.db.functions import duration_seconds
 from warden.lib.models import Job, Session
 
 logger = getLogger(__name__)
@@ -54,10 +55,9 @@ async def get_accounting_snapshot(
         select(
             Session.user_id,
             func.count(Session.id).label("session_count"),
-            # Check
             func.coalesce(
                 func.sum(
-                    func.extract("epoch", Session.revoked_at - Session.created_at)
+                    duration_seconds(Session.created_at, Session.revoked_at),
                 ),
                 0,
             ).label("total_session_duration"),
@@ -78,25 +78,38 @@ async def get_accounting_snapshot(
         user_id = session_row.user_id
         user_sessions_summary[user_id] = SessionsSummary(
             count=session_row.session_count,
-            total_duration=session_row.total_session_duration,
+            total_duration=int(session_row.total_session_duration or 0),
         )
 
-    # Query to get jobs data aggregated by user_id and job status
+    if not user_sessions_summary:
+        return GetAcctResponse(
+            data=[],
+            pagination=PaginationResponse(
+                total=total_count,
+                start=params.offset,
+                end=params.offset,
+            ),
+        )
+
+    # Query to get jobs data aggregated by user_id and job status.
+    # This aggregation has one row per (user, status), so it cannot share the
+    # request's offset/limit with the sessions aggregation above. It is instead
+    # restricted to the users on the page that query just returned.
     jobs_stmt = (
         select(
             Session.user_id,
             Job.status,
             func.count(Job.id).label("job_count"),
             func.coalesce(
-                func.sum(func.extract("epoch", Job.ended_at - Job.started_at)), 0
+                func.sum(duration_seconds(Job.started_at, Job.ended_at)), 0
             ).label("total_job_duration"),
         )
-        .join(Session, Session.id == Job.session_id, isouter=True)
-        .where(and_(*session_filters))
+        .join(Session, Session.id == Job.session_id)
+        .where(
+            and_(*session_filters, Session.user_id.in_(user_sessions_summary.keys()))
+        )
         .group_by(Session.user_id, Job.status)
         .order_by(Session.user_id)
-        .offset(params.offset)
-        .limit(params.limit)
     )
 
     jobs_result = await db_session.execute(jobs_stmt)

--- a/warden/api/routes/acct.py
+++ b/warden/api/routes/acct.py
@@ -84,10 +84,8 @@ async def get_accounting_snapshot(
     if not user_sessions_summary:
         return GetAcctResponse(
             data=[],
-            pagination=PaginationResponse(
-                total=total_count,
-                start=params.offset,
-                end=params.offset,
+            pagination=PaginationResponse.for_page(
+                offset=params.offset, count=0, total=total_count
             ),
         )
 
@@ -142,10 +140,8 @@ async def get_accounting_snapshot(
 
         acct_data_list.append(user_acct_data)
 
-    pagination_resp = PaginationResponse(
-        total=total_count,
-        start=params.offset,
-        end=min(params.offset + len(acct_data_list), total_count),
+    pagination_resp = PaginationResponse.for_page(
+        offset=params.offset, count=len(acct_data_list), total=total_count
     )
 
     return GetAcctResponse(

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -12,9 +12,7 @@ class PaginationResponse(BaseModel):
     end: int
 
     @classmethod
-    def for_page(
-        cls, *, offset: int, count: int, total: int
-    ) -> "PaginationResponse":
+    def for_page(cls, *, offset: int, count: int, total: int) -> "PaginationResponse":
         """Pagination for a page holding ``count`` items starting at ``offset``.
 
         ``start`` is clamped to ``total`` so it never points beyond the data

--- a/warden/api/schemas/acct.py
+++ b/warden/api/schemas/acct.py
@@ -11,6 +11,19 @@ class PaginationResponse(BaseModel):
     start: int
     end: int
 
+    @classmethod
+    def for_page(
+        cls, *, offset: int, count: int, total: int
+    ) -> "PaginationResponse":
+        """Pagination for a page holding ``count`` items starting at ``offset``.
+
+        ``start`` is clamped to ``total`` so it never points beyond the data
+        (e.g. an offset past the end), which keeps the invariant
+        ``start <= end <= total`` and ``end - start == count``.
+        """
+        start = min(offset, total)
+        return cls(total=total, start=start, end=start + count)
+
 
 class SessionsSummary(BaseModel):
     count: int

--- a/warden/lib/db/functions.py
+++ b/warden/lib/db/functions.py
@@ -1,0 +1,54 @@
+"""Portable SQL expressions.
+
+Warden supports SQLite, PostgreSQL and MariaDB, which do not share a way to
+express an elapsed duration between two datetime columns. These helpers compile
+to the right expression per dialect.
+"""
+
+from sqlalchemy import Numeric, func, text
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import FunctionElement
+
+
+class duration_seconds(FunctionElement):
+    """Seconds elapsed between two datetime columns.
+
+    Usage: ``duration_seconds(started_at, ended_at)``. NULL on either side
+    yields NULL, so it composes with ``func.sum`` the usual way.
+    """
+
+    type = Numeric()
+    inherit_cache = True
+    name = "duration_seconds"
+
+
+@compiles(duration_seconds, "postgresql")
+def _duration_seconds_postgresql(element, compiler, **kw):
+    start, end = list(element.clauses)
+    return compiler.process(func.extract("epoch", end - start), **kw)
+
+
+@compiles(duration_seconds, "sqlite")
+def _duration_seconds_sqlite(element, compiler, **kw):
+    # SQLite has no interval type: subtracting datetimes coerces them to
+    # numbers. julianday() gives fractional days, which we scale to seconds.
+    # The scaling is lossy in binary floating point (an exact hour comes back
+    # as 3599.999...), so round to whole seconds like the other backends.
+    start, end = list(element.clauses)
+    return compiler.process(
+        func.round((func.julianday(end) - func.julianday(start)) * 86400.0), **kw
+    )
+
+
+@compiles(duration_seconds, "mysql")
+def _duration_seconds_mysql(element, compiler, **kw):
+    # MariaDB is served by the mysql dialect. EXTRACT has no epoch unit here.
+    start, end = list(element.clauses)
+    return compiler.process(func.timestampdiff(text("SECOND"), start, end), **kw)
+
+
+@compiles(duration_seconds)
+def _duration_seconds_default(element, compiler, **kw):
+    raise NotImplementedError(
+        f"duration_seconds() is not implemented for dialect {compiler.dialect.name!r}."
+    )


### PR DESCRIPTION
Targets `feat/70-report-usage-per-user-in-warden-over-a-time-period`.

**The tests in this first commit are expected to fail.** They pin two bugs in the accounting endpoint that the current suite does not cover. A fix commit follows once CI has confirmed the failures.

### 1. Reported durations are only correct on PostgreSQL

`acct.py:56` and `acct.py:85` use `extract('epoch', ...)`, which only has the intended meaning on PostgreSQL. All three backends are in `TEST_DATABASE_BACKENDS`:

| Backend | Behaviour |
|---|---|
| Postgres | correct |
| SQLite | silently wrong — a 1h session reports `-210866760000` instead of `3600`, because SQLAlchemy maps this to `strftime('%s', ...)` over a numeric subtraction of date strings |
| MariaDB | 500 — no `epoch` unit exists |

No existing assertion reads `total_duration`, which is why CI is green. `test_acct_reported_durations` pins the value.

### 2. Job stats do not belong to the users on the returned page

The sessions aggregation groups by `user_id`; the jobs aggregation groups by `(user_id, status)`. Both then apply the same `.offset()/.limit()`. Since the two groupings yield different row counts, the pages describe different sets of users.

With 6 users x 3 statuses, `?limit=3&offset=3` returns users 1003-1005 each reporting `jobs.count=0`, while the jobs page landed on users 1000/1001.

This passes today only because `acct_populate_db` creates exactly one job with one status per user, so the two paginations coincidentally align. `acct_populate_db` gains a `job_statuses` parameter so the aggregations can be made to diverge; `test_acct_jobs_are_aligned_with_paginated_users` pins the alignment.

### Not covered here

Whether currently-active sessions (`revoked_at IS NULL`, excluded by `acct.py:32`) should be reported, and whether session durations should be clamped to the requested window, are semantic decisions for the endpoint author rather than clear bugs — so no test asserts either way.

### Local results before the fix

- sqlite: `test_acct_reported_durations`, `test_acct_jobs_are_aligned_with_paginated_users` fail
- postgres: `test_acct_jobs_are_aligned_with_paginated_users` fails
- mariadb: all 5 acct tests fail (3 pre-existing ones included)
