### PR TITLE
Add httpx2 as dev dependency to fix warning from starlette test clien…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -964,6 +964,28 @@ socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
+name = "httpcore2"
+version = "2.7.0"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b"},
+    {file = "httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc"},
+]
+
+[package.dependencies]
+h11 = ">=0.16"
+truststore = ">=0.10"
+
+[package.extras]
+asyncio = ["anyio (>=4.5.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 description = "A collection of framework independent HTTP protocol utils."
@@ -1049,15 +1071,42 @@ socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "httpx2"
+version = "2.7.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4"},
+    {file = "httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07"},
+]
+
+[package.dependencies]
+anyio = ">=4.10"
+httpcore2 = "2.7.0"
+idna = ">=3.18"
+truststore = ">=0.10"
+typing-extensions = {version = ">=4.5.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (>=8.4)", "pygments (==2.*)", "rich (>=10,<16)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+ws = ["wsproto (>=1.2)"]
+zstd = ["zstandard (>=0.18.0) ; python_version <= \"3.13\""]
+
+[[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
-    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
@@ -2774,6 +2823,18 @@ typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+description = "Verify certificates using native system trust stores"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -3120,4 +3181,4 @@ postgres = ["asyncpg", "psycopg"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "066e1ae13bebe8af1fc765eac6861163704006a3f36c0586c908df7aea928a62"
+content-hash = "373386ef63d4e2bea1fed023f26429a2427ffef67dab2f333e70bf4ae0c0dc95"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ httpx = "^0.28.1"
 ruff = "^0.15.6"
 pytest-httpx = "^0.36.0"
 pyright = "^1.1.409"
+httpx2 = "^2.7.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = "1.10.0,<1.11"

--- a/requirements-mariadb.txt
+++ b/requirements-mariadb.txt
@@ -608,9 +608,9 @@ httptools==0.8.0 ; python_version >= "3.11" and python_version < "3.13" \
 httpx==0.28.1 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
-idna==3.17 ; python_version >= "3.11" and python_version < "3.13" \
-    --hash=sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c \
-    --hash=sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f
+idna==3.18 ; python_version >= "3.11" and python_version < "3.13" \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
+    --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
 jsonschema-specifications==2025.9.1 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
     --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d

--- a/requirements-pg.txt
+++ b/requirements-pg.txt
@@ -611,9 +611,9 @@ httptools==0.8.0 ; python_version >= "3.11" and python_version < "3.13" \
 httpx==0.28.1 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
-idna==3.17 ; python_version >= "3.11" and python_version < "3.13" \
-    --hash=sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c \
-    --hash=sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f
+idna==3.18 ; python_version >= "3.11" and python_version < "3.13" \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
+    --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
 jsonschema-specifications==2025.9.1 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
     --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d

--- a/requirements.txt
+++ b/requirements.txt
@@ -566,9 +566,9 @@ httptools==0.8.0 ; python_version >= "3.11" and python_version < "3.13" \
 httpx==0.28.1 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
-idna==3.17 ; python_version >= "3.11" and python_version < "3.13" \
-    --hash=sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c \
-    --hash=sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f
+idna==3.18 ; python_version >= "3.11" and python_version < "3.13" \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
+    --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
 jsonschema-specifications==2025.9.1 ; python_version >= "3.11" and python_version < "3.13" \
     --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
     --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d

--- a/tests/scheduler/test_scheduler_integration.py
+++ b/tests/scheduler/test_scheduler_integration.py
@@ -67,7 +67,7 @@ async def test_run_scheduler_integration(
     app = mock_qpu_api_app
     # No need for timing of job execution in this test
     app.state.timed_config = TimedConfig(shot_duration_s=0)
-    conf.qpu._client = TestClient(app)
+    conf.qpu._client = TestClient(app)  # type: ignore[assignment]  # TestClient is httpx2-based
     #################################
 
     ##################
@@ -158,7 +158,7 @@ async def test_run_scheduler_integration_cancellation_worker(
     # the cancellation worker has time to observe and cancel jobs
     app.state.timed_config = TimedConfig(shot_duration_s=0.001)
     # Each job with 500 shots is expected to take 0.5 seconds to complete
-    conf.qpu._client = TestClient(app)
+    conf.qpu._client = TestClient(app)  # type: ignore[assignment]  # TestClient is httpx2-based
     #################################
 
     ##################


### PR DESCRIPTION
We get this warning when running our test suite:
```
============================================================================== warnings summary ==============================================================================
.venv/lib64/python3.12/site-packages/fastapi/testclient.py:1
  /workspace/shared/warden/.venv/lib64/python3.12/site-packages/fastapi/testclient.py:1: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient as TestClient  # noqa

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================= 63 passed, 1 warning in 10.31s ======================================================================
```

Which comes from 
```
from fastapi.testclient import TestClient
```
in `test_scheduler_integration.py`.

This is fixed by adding httpx2 as dev dependency: https://github.com/fastapi/fastapi/discussions/15742

HTTPX2 is the continuation of HTTPX from pydantic: https://github.com/pydantic/httpx2
